### PR TITLE
Add drop-down for FBS scheduler pieces

### DIFF
--- a/docs/fbs-api-basis-functions.rst
+++ b/docs/fbs-api-basis-functions.rst
@@ -1,0 +1,11 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-basis-functions:
+
+Basis Functions
+^^^^^^^^^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.basis_functions
+    :imported-members:
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-detailers.rst
+++ b/docs/fbs-api-detailers.rst
@@ -1,0 +1,11 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-details:
+
+Detailers
+^^^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.detailers
+    :imported-members:
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-example-scheduler.rst
+++ b/docs/fbs-api-example-scheduler.rst
@@ -1,0 +1,12 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-example-scheduler:
+
+
+Example Scheduler
+^^^^^^^^^^^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.example.example_scheduler
+    :imported-members:
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-features.rst
+++ b/docs/fbs-api-features.rst
@@ -1,0 +1,11 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-features:
+
+Features
+^^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.features
+    :imported-members:
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-model-observatory.rst
+++ b/docs/fbs-api-model-observatory.rst
@@ -1,0 +1,11 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-model-observatory:
+
+Model Observatory
+^^^^^^^^^^^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.model_observatory
+    :imported-members:
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-schedulers.rst
+++ b/docs/fbs-api-schedulers.rst
@@ -1,0 +1,11 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-schedulers:
+
+Schedulers
+^^^^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.schedulers
+    :imported-members:
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-sim-runner.rst
+++ b/docs/fbs-api-sim-runner.rst
@@ -1,0 +1,10 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-sim-runner:
+
+Sim Runner
+^^^^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.sim_runner
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-surveys.rst
+++ b/docs/fbs-api-surveys.rst
@@ -1,0 +1,11 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-surveys:
+
+Surveys
+^^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.surveys
+    :imported-members:
+    :members:
+    :show-inheritance:

--- a/docs/fbs-api-utils.rst
+++ b/docs/fbs-api-utils.rst
@@ -1,0 +1,12 @@
+.. py:currentmodule:: rubin_scheduler.scheduler
+
+.. _fbs-api-utils:
+
+Utils
+^^^^^^
+
+.. automodule:: rubin_scheduler.scheduler.utils
+    :imported-members:
+    :members:
+    :show-inheritance:
+

--- a/docs/fbs-api.rst
+++ b/docs/fbs-api.rst
@@ -6,74 +6,25 @@
 FBS Scheduler API
 =================
 
-Sim Runner
-^^^^^^^^^^
+.. toctree::
 
-.. automodule:: rubin_scheduler.scheduler.sim_runner
-    :members:
-    :show-inheritance:
+    Sim Runner <fbs-api-sim-runner>
 
-Example Scheduler
-^^^^^^^^^^^^^^^^^
+    Example Scheduler <fbs-api-example-scheduler>
 
-.. automodule:: rubin_scheduler.scheduler.example.example_scheduler
-    :imported-members:
-    :members:
-    :show-inheritance:
+    Model Observatory <fbs-api-model-observatory>
 
-Model Observatory
-^^^^^^^^^^^^^^^^^
+    Schedulers <fbs-api-schedulers>
 
-.. automodule:: rubin_scheduler.scheduler.model_observatory
-    :imported-members:
-    :members:
-    :show-inheritance:
+    Surveys <fbs-api-surveys>
 
-Schedulers
-^^^^^^^^^^
+    Basis Functions <fbs-api-basis-functions>
 
-.. automodule:: rubin_scheduler.scheduler.schedulers
-    :imported-members:
-    :members:
-    :show-inheritance:
+    Features <fbs-api-features>
 
-Surveys
-^^^^^^^
+    Detailers <fbs-api-detailers>
 
-.. automodule:: rubin_scheduler.scheduler.surveys
-    :imported-members:
-    :members:
-    :show-inheritance:
+    Utils <fbs-api-utils>
 
-Basis Functions
-^^^^^^^^^^^^^^^
 
-.. automodule:: rubin_scheduler.scheduler.basis_functions
-    :imported-members:
-    :members:
-    :show-inheritance:
-
-Features
-^^^^^^^^
-
-.. automodule:: rubin_scheduler.scheduler.features
-    :imported-members:
-    :members:
-    :show-inheritance:
-
-Detailers
-^^^^^^^^^
-
-.. automodule:: rubin_scheduler.scheduler.detailers
-    :imported-members:
-    :members:
-    :show-inheritance:
-
-Utils
-^^^^^^
-
-.. automodule:: rubin_scheduler.scheduler.utils
-    :imported-members:
-    :members:
-    :show-inheritance:
 


### PR DESCRIPTION
Make it easier to find specific classes relating to the scheduler within the FBS API documentation. 