### PR TITLE
let scripted observations check for twilight starting

### DIFF
--- a/rubin_scheduler/scheduler/surveys/base_survey.py
+++ b/rubin_scheduler/scheduler/surveys/base_survey.py
@@ -216,8 +216,9 @@ class BaseSurvey:
 
     def generate_observations(self, conditions):
         observations = self.generate_observations_rough(conditions)
-        for detailer in self.detailers:
-            observations = detailer(observations, conditions)
+        if np.size(observations) > 0:
+            for detailer in self.detailers:
+                observations = detailer(observations, conditions)
         return observations
 
     def viz_config(self):

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -37,7 +37,6 @@ class TestUtils(unittest.TestCase):
         # start date changes, e.g., different DDFs in season, or different lunar phase
         # means different filters get picked for the blobs
         notes_to_check = [
-            "DD:COSMOS",
             "blob_long, gr, a",
             "blob_long, gr, b",
             "greedy",
@@ -56,8 +55,6 @@ class TestUtils(unittest.TestCase):
             "pair_33, ug, b",
             "pair_33, yy, a",
             "pair_33, yy, b",
-            "pair_33, zy, a",
-            "pair_33, zy, b",
             "twilight_near_sun, 0",
             "twilight_near_sun, 1",
             "twilight_near_sun, 2",
@@ -65,6 +62,10 @@ class TestUtils(unittest.TestCase):
         ]
 
         for note in notes_to_check:
+            assert note in u_notes
+
+        for note in u_notes:
+            # If this fails, time to add something to notes_to_check
             assert note in u_notes
 
     @unittest.skipUnless(


### PR DESCRIPTION
Update scripted surveys to have logic that will prevent long sequences from executing right before twilight. Mainly for DDFs. 