### PR TITLE
Tickets/opsim 1114 Add jerk to the telescope kinematic model

### DIFF
--- a/rubin_scheduler/scheduler/model_observatory/__init__.py
+++ b/rubin_scheduler/scheduler/model_observatory/__init__.py
@@ -1,3 +1,3 @@
+from .jerk import *
 from .kinem_model import *
 from .model_observatory import *
-from .jerk import *

--- a/rubin_scheduler/scheduler/model_observatory/__init__.py
+++ b/rubin_scheduler/scheduler/model_observatory/__init__.py
@@ -1,2 +1,3 @@
 from .kinem_model import *
 from .model_observatory import *
+from .jerk import *

--- a/rubin_scheduler/scheduler/model_observatory/jerk.py
+++ b/rubin_scheduler/scheduler/model_observatory/jerk.py
@@ -20,7 +20,7 @@ def jerk_time(distance, v_max, acc_max, jerk_max):
     acc_max : `float`
         The maximum acceleration. Units of length or angle per unit of time squared.
     jerk_max : `float`
-        The maximum jerk. Units of length or angle per unit of time cubed. If 
+        The maximum jerk. Units of length or angle per unit of time cubed. If
         set to None, assumes jerk is infinite and defaults to use acc_time.
     """
 
@@ -31,14 +31,12 @@ def jerk_time(distance, v_max, acc_max, jerk_max):
     if jerk_max is None:
         return acc_time(distance, v_max, acc_max)
 
-    trajectory_instance_case = get_trajectory_instance_case(
-        distance, v_max, acc_max, jerk_max
-    )
+    trajectory_instance_case = _get_trajectory_instance_case(distance, v_max, acc_max, jerk_max)
 
     unique_trag = np.unique(trajectory_instance_case)
 
     if np.size(unique_trag) == 1:
-        tj, ta, tv = calculate_times(
+        tj, ta, tv = _calculate_times(
             distance,
             v_max,
             acc_max,
@@ -50,7 +48,7 @@ def jerk_time(distance, v_max, acc_max, jerk_max):
         result = np.zeros(np.size(distance))
         for tic in unique_trag:
             indx = np.where(trajectory_instance_case == tic)[0]
-            tj, ta, tv = calculate_times(
+            tj, ta, tv = _calculate_times(
                 distance[indx],
                 v_max,
                 acc_max,
@@ -88,7 +86,11 @@ def acc_time(distance, v_max, acc_max):
     return slew_time
 
 
-def calculate_times(distance, v_max, acc_max, jerk_max, trajectory_instance_case=1):
+def _calculate_times(distance, v_max, acc_max, jerk_max, trajectory_instance_case=1):
+    """Calculate travel time including jerk.
+
+    Modified from https://github.com/mdhom/py_constant_jerk/blob/main/constantJerk.py
+    """
     if trajectory_instance_case == 1 or trajectory_instance_case == 3:
         tj = np.sqrt(v_max / jerk_max)
         ta = tj
@@ -119,8 +121,23 @@ def calculate_times(distance, v_max, acc_max, jerk_max, trajectory_instance_case
         raise Exception("TrajectoryInstance must be between 1 and 6")
 
 
-def get_trajectory_instance_case(distance, v_max, acc_max, jerk_max):
-    """
+def _get_trajectory_instance_case(distance, v_max, acc_max, jerk_max):
+    """Determine which motion profile to use.
+
+    Modified from https://github.com/mdhom/py_constant_jerk/blob/main/constantJerk.py
+
+    Parameters
+    ----------
+    distance : `float`
+        The distance to travel. Could be units of length or angle as long as other
+        parameters match.
+    v_max : `float`
+        The maximum velocity. Units of length or angle per unit of time.
+    acc_max : `float`
+        The maximum acceleration. Units of length or angle per unit of time squared.
+    jerk_max : `float`
+        The maximum jerk. Units of length or angle per unit of time cubed.
+
     """
     # Case 1: a_max reached, v_max reached and constant for a time
     #          (s = 100,   j = 2000, a = 500,  vMax = 120)

--- a/rubin_scheduler/scheduler/model_observatory/jerk.py
+++ b/rubin_scheduler/scheduler/model_observatory/jerk.py
@@ -6,9 +6,11 @@ import numpy as np
 def jerk_time(distance, v_max, acc_max, jerk_max):
     """Calculate how long to move a distance given maximum jerk, acceleration, and velocity
 
-    All parameters are assumed to be symetric (e.g, minium jerk = -1*jerk_max)
+    All parameters are assumed to be symetric (e.g, minimum jerk = -1*jerk_max)
 
     modified from https://github.com/mdhom/py_constant_jerk/blob/main/constantJerk.py
+    see also:
+    https://www.researchgate.net/publication/289374755_THIRD_ORDER_POINT-TO-POINT_MOTION_-PROFILE
 
     Parameters
     ----------
@@ -125,6 +127,8 @@ def _get_trajectory_instance_case(distance, v_max, acc_max, jerk_max):
     """Determine which motion profile to use.
 
     Modified from https://github.com/mdhom/py_constant_jerk/blob/main/constantJerk.py
+    which was probably derived from:
+    https://www.researchgate.net/publication/289374755_THIRD_ORDER_POINT-TO-POINT_MOTION_-PROFILE
 
     Parameters
     ----------
@@ -162,11 +166,11 @@ def _get_trajectory_instance_case(distance, v_max, acc_max, jerk_max):
     else:
         s_v = v_max * (v_max / acc_max + acc_max / jerk_max)
 
-    result[np.where((v_max <= v_a) & (distance > s_a))] = 1
-    result[np.where((v_max > v_a) & (distance < s_a))] = 2
-    result[np.where((v_max < v_a) & (s_a > distance) & (distance > s_v))] = 3
+    result[np.where((v_max < v_a) & (distance >= s_a))] = 1
+    result[np.where((v_max >= v_a) & (distance < s_a))] = 2
+    result[np.where((v_max < v_a) & (s_a > distance) & (distance >= s_v))] = 3
     result[np.where((v_max < v_a) & (distance < s_a) & (distance < s_v))] = 4
-    result[np.where((v_max > v_a) & (distance > s_a) & (distance >= s_v))] = 5
-    result[np.where((v_max > v_a) & (s_a < distance) & (distance < s_v))] = 6
+    result[np.where((v_max >= v_a) & (distance >= s_a) & (distance >= s_v))] = 5
+    result[np.where((v_max >= v_a) & (s_a <= distance) & (distance < s_v))] = 6
 
     return result

--- a/rubin_scheduler/scheduler/model_observatory/jerk.py
+++ b/rubin_scheduler/scheduler/model_observatory/jerk.py
@@ -1,0 +1,155 @@
+__all__ = ("jerk_time", "acc_time")
+
+import numpy as np
+
+
+def jerk_time(distance, v_max, acc_max, jerk_max):
+    """Calculate how long to move a distance given maximum jerk, acceleration, and velocity
+
+    All parameters are assumed to be symetric (e.g, minium jerk = -1*jerk_max)
+
+    modified from https://github.com/mdhom/py_constant_jerk/blob/main/constantJerk.py
+
+    Parameters
+    ----------
+    distance : `float`
+        The distance to travel. Could be units of length or angle as long as other
+        parameters match.
+    v_max : `float`
+        The maximum velocity. Units of length or angle per unit of time
+    acc_max : `float`
+        The maximum acceleration. Units of length or angle per unit of time squared.
+    jerk_max : `float`
+        The maximum jerk. Units of length or angle per unit of time cubed. If 
+        set to None, assumes jerk is infinite and defaults to use acc_time.
+    """
+
+    # If distance is a scalar, convert to array.
+    distance = np.atleast_1d(distance)
+
+    # If there is no jerk, fall back on infinite jerk approximation
+    if jerk_max is None:
+        return acc_time(distance, v_max, acc_max)
+
+    trajectory_instance_case = get_trajectory_instance_case(
+        distance, v_max, acc_max, jerk_max
+    )
+
+    unique_trag = np.unique(trajectory_instance_case)
+
+    if np.size(unique_trag) == 1:
+        tj, ta, tv = calculate_times(
+            distance,
+            v_max,
+            acc_max,
+            jerk_max,
+            trajectory_instance_case=unique_trag,
+        )
+        result = tv + tj + ta
+    else:
+        result = np.zeros(np.size(distance))
+        for tic in unique_trag:
+            indx = np.where(trajectory_instance_case == tic)[0]
+            tj, ta, tv = calculate_times(
+                distance[indx],
+                v_max,
+                acc_max,
+                jerk_max,
+                trajectory_instance_case=tic,
+            )
+            result[indx] = tv + tj + ta
+
+    return result
+
+
+def acc_time(distance, v_max, acc_max):
+    """Time to move given a maximum velocity and acceleration. Assumes infinite jerk.
+    Velocity and accelerations are assumed to be symetric (minimum acceleration = -1* acc_max)
+
+    Parameters
+    ----------
+    distance : `float`
+        The distance to travel. Could be units of length or angle as long as other
+        parameters match.
+    v_max : `float`
+        The maximum velocity. Units of length or angle per unit of time
+    acc_max : `float`
+        The maximum acceleration. Units of length or angle per unit of time squared.
+    """
+
+    distance = np.atleast_1d(distance)
+
+    dm = v_max**2 / acc_max
+    slew_time = np.where(
+        distance < dm,
+        2 * np.sqrt(distance / acc_max),
+        2 * v_max / acc_max + (distance - dm) / v_max,
+    )
+    return slew_time
+
+
+def calculate_times(distance, v_max, acc_max, jerk_max, trajectory_instance_case=1):
+    if trajectory_instance_case == 1 or trajectory_instance_case == 3:
+        tj = np.sqrt(v_max / jerk_max)
+        ta = tj
+        tv = distance / v_max
+        return tj, ta, tv
+    elif trajectory_instance_case == 2 or trajectory_instance_case == 4:
+        tj = (distance / (2 * jerk_max)) ** (1.0 / 3.0)
+        ta = tj
+        tv = 2 * tj
+        return tj, ta, tv
+    elif trajectory_instance_case == 5:
+        tj = acc_max / jerk_max
+        ta = v_max / acc_max
+        tv = distance / v_max
+        return tj, ta, tv
+    elif trajectory_instance_case == 6:
+        tj = acc_max / jerk_max
+        ta = 0.5 * (
+            np.sqrt(
+                (4 * distance * jerk_max * jerk_max + acc_max * acc_max * acc_max)
+                / (acc_max * jerk_max * jerk_max)
+            )
+            - acc_max / jerk_max
+        )
+        tv = ta + tj
+        return tj, ta, tv
+    else:
+        raise Exception("TrajectoryInstance must be between 1 and 6")
+
+
+def get_trajectory_instance_case(distance, v_max, acc_max, jerk_max):
+    """
+    """
+    # Case 1: a_max reached, v_max reached and constant for a time
+    #          (s = 100,   j = 2000, a = 500,  vMax = 120)
+    # Case 2: a_max not reached, v_max not reached
+    #          (s = 15000, j = 2000, a = 5500, vMax = 20500)
+    # Case 3: a_max not reached, v_max reached and constant for a time
+    #          (s = 15000, j = 2000, a = 5500, vMax = 2500)
+    # Case 4: a_max reached, v_max not reached
+    #          (s = 57,    j = 2000, a = 500,  vMax = 120)
+    # Case 5: a_max reached and constant for a time, v_max reached and constant for a time
+    #          (s = 15000, j = 2000, a = 500,  vMax = 2500)
+    # Case 6: a_max reached and constant for a time, v_max not reached
+    #          (s = 15000, j = 2000, a = 500,  vMax = 20500)
+
+    result = np.array(distance * 0)
+
+    v_a = acc_max * acc_max / jerk_max
+    s_a = 2 * acc_max * acc_max * acc_max / (jerk_max * jerk_max)
+    s_v = 0.0
+    if v_max * jerk_max < acc_max * acc_max:
+        s_v = v_max * 2 * np.sqrt(v_max / jerk_max)
+    else:
+        s_v = v_max * (v_max / acc_max + acc_max / jerk_max)
+
+    result[np.where((v_max <= v_a) & (distance > s_a))] = 1
+    result[np.where((v_max > v_a) & (distance < s_a))] = 2
+    result[np.where((v_max < v_a) & (s_a > distance) & (distance > s_v))] = 3
+    result[np.where((v_max < v_a) & (distance < s_a) & (distance < s_v))] = 4
+    result[np.where((v_max > v_a) & (distance > s_a) & (distance >= s_v))] = 5
+    result[np.where((v_max > v_a) & (s_a < distance) & (distance < s_v))] = 6
+
+    return result

--- a/rubin_scheduler/scheduler/model_observatory/kinem_model.py
+++ b/rubin_scheduler/scheduler/model_observatory/kinem_model.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from rubin_scheduler.scheduler.utils import smallest_signed_angle
 from rubin_scheduler.utils import Site, _approx_altaz2pa, _approx_ra_dec2_alt_az, approx_alt_az2_ra_dec
+from .jerk import jerk_time
 
 __all__ = ("KinemModel",)
 two_pi = 2.0 * np.pi
@@ -104,8 +105,8 @@ class KinemModel:
         rotator_max=90,
         maxspeed=3.5,
         accel=1.0,
-        decel=1.0,
         shutter_2motion_min_time=15.0,
+        jerk=None,
     ):
         """
         Parameters
@@ -126,6 +127,8 @@ class KinemModel:
             The maximum speed of the rotator (degrees/s)
         accel : `float` (1.0)
             The acceleration of the rotator (degrees/s^2)
+        jerk : `float`
+            The jerk of the rotator (degrees/s^3). Default of None treats jerk as infinite
         shutter_2motion_min_time : `float` (15.)
             The time required for two shutter motions (seconds). If one takes
             a 1-snap 10s exposure, there will be a 5s of overhead before the next exposure can start.
@@ -139,7 +142,7 @@ class KinemModel:
         self.telrot_maxpos_rad = np.radians(rotator_max)
         self.telrot_maxspeed_rad = np.radians(maxspeed)
         self.telrot_accel_rad = np.radians(accel)
-        self.telrot_decel_rad = np.radians(decel)
+        self.telrot_jerk_rad = np.radians(jerk) if jerk is not None else None
         self.shutter_2motion_min_time = shutter_2motion_min_time
         self.mounted_filters = ["u", "g", "r", "i", "y"]
 
@@ -147,11 +150,11 @@ class KinemModel:
         self,
         altitude_maxspeed=1.75,
         altitude_accel=0.875,
-        altitude_decel=0.875,
+        altitude_jerk=None,
         altitude_freerange=0.0,
         azimuth_maxspeed=1.5,
         azimuth_accel=0.75,
-        azimuth_decel=0.75,
+        azimuth_jerk=None,
         azimuth_freerange=4.0,
         settle_time=1.0,
     ):
@@ -163,16 +166,18 @@ class KinemModel:
             Maximum speed for altitude movement (degrees/second)
         altitude_accel : `float` (0.875)
             Maximum acceleration for altitude movement (degrees/second**2)
-        altitude_decel : `float` (0.875)
-            Maximum deceleration for altitude movement (degrees/second**2)
+        altitude_jerk : `float`
+            The jerk for the altitude movement (degrees/second**3). Default 
+            of None treats jerk as infinite.
         altitude_freerange : `float` (0)
             The range over which there is 0 delay
         azimuth_maxspeed : `float` (1.5)
             Maximum speed for azimuth movement (degrees/second)
         azimuth_accel : `float` (0.75)
             Maximum acceleration for azimuth movement (degrees/second**2)
-        azimuth_decel : `float` (0.75)
-            Maximum deceleration for azimuth movement (degrees/second**2)
+        azimuth_jerk : `float`
+            The jerk of the azimuth movement (degrees/second**3). Default 
+            of None treats jerk as infinite.
         azimuth_freerange : `float` (4.0)
             The range in which there is 0 delay
         settle_time : `float` (1.0)
@@ -180,11 +185,11 @@ class KinemModel:
         """
         self.domalt_maxspeed_rad = np.radians(altitude_maxspeed)
         self.domalt_accel_rad = np.radians(altitude_accel)
-        self.domalt_decel_rad = np.radians(altitude_decel)
+        self.domalt_jerk_rad = np.radians(altitude_jerk) if altitude_jerk is not None else None
         self.domalt_free_range = np.radians(altitude_freerange)
         self.domaz_maxspeed_rad = np.radians(azimuth_maxspeed)
         self.domaz_accel_rad = np.radians(azimuth_accel)
-        self.domaz_decel_rad = np.radians(azimuth_decel)
+        self.domaz_jerk_rad = np.radians(azimuth_jerk) if azimuth_jerk is not None else None
         self.domaz_free_range = np.radians(azimuth_freerange)
         self.domaz_settletime = settle_time
 
@@ -196,10 +201,10 @@ class KinemModel:
         azimuth_maxpos=250.0,
         altitude_maxspeed=3.5,
         altitude_accel=3.5,
-        altitude_decel=3.5,
+        altitude_jerk=None,
         azimuth_maxspeed=7.0,
         azimuth_accel=7.0,
-        azimuth_decel=7.0,
+        azimuth_jerk=None,
         settle_time=3.0,
         az_limits=None,
         alt_limits=None,
@@ -220,14 +225,10 @@ class KinemModel:
             Maximum speed for altitude movement (degrees/second)
         altitude_accel : `float` (3.5)
             Maximum acceleration for altitude movement (degrees/second**2)
-        altitude_decel : `float` (3.5)
-            Maximum deceleration for altitude movement (degrees/second**2)
         azimuth_maxspeed : `float` (7.0)
             Maximum speed for azimuth movement (degrees/second)
         azimuth_accel : `float` (7.0)
             Maximum acceleration for azimuth movement (degrees/second**2)
-        azimuth_decel : `float` (7.0)
-            Maximum deceleration for azimuth movement (degrees/second**2)
         settle_time : `float` (3.0)
             Settle time required for telescope after movement (seconds)
         """
@@ -237,10 +238,10 @@ class KinemModel:
         self.telaz_maxpos_rad = np.radians(azimuth_maxpos)
         self.telalt_maxspeed_rad = np.radians(altitude_maxspeed)
         self.telalt_accel_rad = np.radians(altitude_accel)
-        self.telalt_decel_rad = np.radians(altitude_decel)
+        self.telalt_jerk_rad = np.radians(altitude_jerk) if altitude_jerk is not None else None
         self.telaz_maxspeed_rad = np.radians(azimuth_maxspeed)
         self.telaz_accel_rad = np.radians(azimuth_accel)
-        self.telaz_decel_rad = np.radians(azimuth_decel)
+        self.telaz_jerk_rad = np.radians(azimuth_jerk) if azimuth_jerk is not None else None
         self.mount_settletime = settle_time
         if alt_limits is None:
             self.alt_limits = [[self.telalt_minpos_rad, self.telalt_maxpos_rad]]
@@ -305,43 +306,6 @@ class KinemModel:
             alt_rad, az_rad, pa = self.radec2altaz(self.current_ra_rad, self.current_dec_rad, mjd)
             rot_tel_pos = _get_rot_tel_pos(pa, self.last_rot_tel_pos_rad)
             return alt_rad, az_rad, rot_tel_pos
-
-    def _uam_slew_time(self, distance, vmax, accel):
-        """Compute slew time delay assuming uniform acceleration
-        (for any component).
-
-        If you accelerate uniformly to vmax, then slow down uniformly to zero,
-        distance traveled is  d  = vmax**2 / accel
-        To travel distance d while accelerating/decelerating at rate a,
-        time required is t = 2 * sqrt(d / a)
-        If hit vmax, then time to acceleration to/from vmax is 2*vmax/a and
-        distance in those steps is vmax**2/a.
-        The remaining distance is (d - vmax^2/a) and
-        time needed is (d - vmax^2/a)/vmax
-
-        This method accepts arrays of distance,
-        and assumes acceleration == deceleration.
-
-        Parameters
-        ----------
-        distance : `np.ndarray`, (N,)
-            Distances to travel. Must be positive value.
-        vmax : `float`
-            Max velocity
-        accel : `float`
-            Acceleration (and deceleration)
-
-        Returns
-        -------
-        slew_time : `np.ndarray`, (N,)
-        """
-        dm = vmax**2 / accel
-        slew_time = np.where(
-            distance < dm,
-            2 * np.sqrt(distance / accel),
-            2 * vmax / accel + (distance - dm) / vmax,
-        )
-        return slew_time
 
     def slew_times(
         self,
@@ -483,9 +447,9 @@ class KinemModel:
         )
 
         # Calculate how long the telescope will take to slew to this position.
-        tel_alt_slew_time = self._uam_slew_time(delta_alt, self.telalt_maxspeed_rad, self.telalt_accel_rad)
-        tel_az_slew_time = self._uam_slew_time(
-            np.abs(delta_aztel), self.telaz_maxspeed_rad, self.telaz_accel_rad
+        tel_alt_slew_time = jerk_time(delta_alt, self.telalt_maxspeed_rad, self.telalt_accel_rad, self.telalt_jerk_rad)
+        tel_az_slew_time = jerk_time(
+            np.abs(delta_aztel), self.telaz_maxspeed_rad, self.telaz_accel_rad, self.telaz_jerk_rad
         )
         tot_tel_time = np.maximum(tel_alt_slew_time, tel_az_slew_time)
 
@@ -541,10 +505,11 @@ class KinemModel:
         else:
             # the above models a dome slit and dome creep. However, it appears that
             # SOCS requires the dome to slew exactly to each field and settle in az
-            dom_alt_slew_time = self._uam_slew_time(
-                delta_alt, self.domalt_maxspeed_rad, self.domalt_accel_rad
+            dom_alt_slew_time = jerk_time(
+                delta_alt, self.domalt_maxspeed_rad, self.domalt_accel_rad, self.domalt_jerk_rad
             )
-            dom_az_slew_time = self._uam_slew_time(delta_az, self.domaz_maxspeed_rad, self.domaz_accel_rad)
+            dom_az_slew_time = jerk_time(delta_az, self.domaz_maxspeed_rad, self.domaz_accel_rad, self.domaz_jerk_rad)
+            
             # Dome takes 1 second to settle in az
             dom_az_slew_time = np.where(
                 dom_az_slew_time > 0,
@@ -593,8 +558,8 @@ class KinemModel:
                 # kwarg overrides if it was supplied
                 current_rot_tel_pos = starting_rot_tel_pos_rad
             delta_rotation = np.abs(smallest_signed_angle(current_rot_tel_pos, rot_tel_pos))
-            rotator_time = self._uam_slew_time(
-                delta_rotation, self.telrot_maxspeed_rad, self.telrot_accel_rad
+            rotator_time = jerk_time(
+                delta_rotation, self.telrot_maxspeed_rad, self.telrot_accel_rad, self.telrot_jerk_rad
             )
             slew_time = np.maximum(slew_time, rotator_time)
 

--- a/rubin_scheduler/scheduler/model_observatory/kinem_model.py
+++ b/rubin_scheduler/scheduler/model_observatory/kinem_model.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from rubin_scheduler.scheduler.utils import smallest_signed_angle
 from rubin_scheduler.utils import Site, _approx_altaz2pa, _approx_ra_dec2_alt_az, approx_alt_az2_ra_dec
+
 from .jerk import jerk_time
 
 __all__ = ("KinemModel",)
@@ -167,7 +168,7 @@ class KinemModel:
         altitude_accel : `float` (0.875)
             Maximum acceleration for altitude movement (degrees/second**2)
         altitude_jerk : `float`
-            The jerk for the altitude movement (degrees/second**3). Default 
+            The jerk for the altitude movement (degrees/second**3). Default
             of None treats jerk as infinite.
         altitude_freerange : `float` (0)
             The range over which there is 0 delay
@@ -176,7 +177,7 @@ class KinemModel:
         azimuth_accel : `float` (0.75)
             Maximum acceleration for azimuth movement (degrees/second**2)
         azimuth_jerk : `float`
-            The jerk of the azimuth movement (degrees/second**3). Default 
+            The jerk of the azimuth movement (degrees/second**3). Default
             of None treats jerk as infinite.
         azimuth_freerange : `float` (4.0)
             The range in which there is 0 delay
@@ -447,7 +448,9 @@ class KinemModel:
         )
 
         # Calculate how long the telescope will take to slew to this position.
-        tel_alt_slew_time = jerk_time(delta_alt, self.telalt_maxspeed_rad, self.telalt_accel_rad, self.telalt_jerk_rad)
+        tel_alt_slew_time = jerk_time(
+            delta_alt, self.telalt_maxspeed_rad, self.telalt_accel_rad, self.telalt_jerk_rad
+        )
         tel_az_slew_time = jerk_time(
             np.abs(delta_aztel), self.telaz_maxspeed_rad, self.telaz_accel_rad, self.telaz_jerk_rad
         )
@@ -508,8 +511,10 @@ class KinemModel:
             dom_alt_slew_time = jerk_time(
                 delta_alt, self.domalt_maxspeed_rad, self.domalt_accel_rad, self.domalt_jerk_rad
             )
-            dom_az_slew_time = jerk_time(delta_az, self.domaz_maxspeed_rad, self.domaz_accel_rad, self.domaz_jerk_rad)
-            
+            dom_az_slew_time = jerk_time(
+                delta_az, self.domaz_maxspeed_rad, self.domaz_accel_rad, self.domaz_jerk_rad
+            )
+
             # Dome takes 1 second to settle in az
             dom_az_slew_time = np.where(
                 dom_az_slew_time > 0,

--- a/tests/scheduler/test_modelobs.py
+++ b/tests/scheduler/test_modelobs.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import rubin_scheduler.utils as utils
-from rubin_scheduler.scheduler.model_observatory import ModelObservatory, acc_time, jerk_time
+from rubin_scheduler.scheduler.model_observatory import KinemModel, ModelObservatory, acc_time, jerk_time
 
 
 class KindaClouds:
@@ -91,6 +91,14 @@ class TestModelObservatory(unittest.TestCase):
         t2 = jerk_time(np.radians(distance), np.radians(v_max), np.radians(acc_max), np.radians(jerk_max))
 
         assert np.allclose(t1, t2, atol=1e-7)
+
+        # test if values are equal case.
+        distance = 4.5  # degrees
+        v_max = 3.5  # deg/s
+        acc_max = 3.5  # deg/s/s
+        jerk_max = 3.5  # deg/s/s/s
+
+        t1 = jerk_time(distance, v_max, acc_max, jerk_max)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the kinematic model of the telescope to include jerk. All jerks and accelerations assumed to be symmetric (e.g., maximum deceleration equals negative maximum acceleration). Removed previously unused deceleration kwargs. 