### PR TITLE
OPSIM-1135 Move 'get_baseline' to rubin-sim

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Access rubin-sim-data cache
         id: cache-rs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-rubin-sim-data
         with:

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Access rubin-sim-data cache
         id: cache-rs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-rubin-sim-data
         with:

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Access rubin-sim-data cache
         id: cache-rs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cached-rubin-sim-data
         with:

--- a/rubin_scheduler/data/data_sets.py
+++ b/rubin_scheduler/data/data_sets.py
@@ -1,4 +1,4 @@
-__all__ = ("get_data_dir", "data_versions", "get_baseline")
+__all__ = ("get_data_dir", "data_versions")
 
 import glob
 import os
@@ -19,20 +19,6 @@ def get_data_dir():
     if data_dir is None:
         data_dir = os.path.join(os.getenv("HOME"), "rubin_sim_data")
     return data_dir
-
-
-def get_baseline():
-    """Get the path to the baseline cadence simulation sqlite file.
-
-    Returns
-    -------
-    file : `str`
-        Path to the baseline cadence simulation sqlite file.
-    """
-    dd = get_data_dir()
-    path = os.path.join(dd, "sim_baseline")
-    file = glob.glob(path + "/*10yrs.db")[0]
-    return file
 
 
 def data_versions():

--- a/rubin_scheduler/data/scheduler_download_data.py
+++ b/rubin_scheduler/data/scheduler_download_data.py
@@ -164,9 +164,9 @@ def download_rubin_data(
 
     # See if base URL is alive
     url_base = url_base
+    fail_message = f"Could not connect to {url_base}. Check site is up?"
     try:
         r = requests.get(url_base)
-        fail_message = f"Could not connect to {url_base} or {url_base}. Check sites are up?"
     except ConnectionError:
         print(fail_message)
         exit()
@@ -206,7 +206,7 @@ def download_rubin_data(
             if file_size < 245:
                 warnings.warn(f"{url} file size unexpectedly small.")
             # Download this size chunk at a time; reasonable guess
-            block_size = 512 * 512
+            block_size = 512 * 512 * 10
             progress_bar = tqdm(total=file_size, unit="iB", unit_scale=True, disable=tdqm_disable)
             print(f"Writing to {os.path.join(data_dir, filename)}")
             with open(os.path.join(data_dir, filename), "wb") as f:

--- a/rubin_scheduler/scheduler/surveys/generate_ddf_grid.py
+++ b/rubin_scheduler/scheduler/surveys/generate_ddf_grid.py
@@ -18,33 +18,28 @@ def generate_ddf_grid(
     delta_t=15.0,
     survey_length=40.0,
     sun_limit=-12,
-    nominal_seeing=0.7,
-    filtername="g",
     nominal_expt=30.0,
 ):
     """Pre-compute conditions for DDF locations over survey
 
     Parameters
     ----------
-    mjd0 : float
+    mjd0 : `float`
         The start MJD of the grid
-    delta_t : float
+    delta_t : `float`
         Spacing of time steps in minutes. Default 15
-    survey_length : float
+    survey_length : `float`
         Full span of DDF grid (years). Default 40.
-    sun_limit : float
-        Ignore times with sun above sun limit in degrees. Default -12.
-    nominal_seeling : float
-        Nominal seeing in arcseconds to assume for depth calculations.
-        Default 0.7
-    filtername : str
-        The filter to use for the grid, default g
-    nominal_expt : float
-        Nominal exposure time in seconds to use for depth visits. Default 30
+    sun_limit : `float`
+        Ignore times with sun above sun limit in degrees.
+        Default -12.
+    nominal_expt : `float`
+        Nominal exposure time in seconds to use for depth visits.
+        Default 30
     """
 
     # Technically this script should be over in rubin_sim, but here to be more
-    # easily found. Burry import here so it's hopefully not a problem.
+    # easily found. Bury import here so it's hopefully not a problem.
     import rubin_sim.skybrightness as sb
     from astroplan import Observer
 


### PR DESCRIPTION
Moves get_baseline to rubin_sim (only). 
The sim baseline is only downloaded with rs_download_data, so having the call to get_baseline() in rubin-scheduler is confusing.

Also updates workflows for node.js 20.