### PR TITLE
OPSIM-1136: Update zero point for calc_season and make it multi-RA capable

### DIFF
--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -6,7 +6,7 @@ __all__ = (
     "DelayStartBasisFunction",
     "TargetMapBasisFunction",
     "AvoidLongGapsBasisFunction",
-    "AvoidFastRevists",
+    "AvoidFastRevisits",
     "VisitRepeatBasisFunction",
     "M5DiffBasisFunction",
     "M5DiffAtHpixBasisFunction",
@@ -55,6 +55,16 @@ from rubin_scheduler.scheduler import features, utils
 from rubin_scheduler.scheduler.utils import IntRounded, get_current_footprint
 from rubin_scheduler.skybrightness_pre import dark_m5
 from rubin_scheduler.utils import _hpid2_ra_dec, survey_start_mjd
+
+
+def send_unused_deprecation_warning(name):
+    message = (
+        f"The basis function {name} is not in use by the current "
+        "baseline scheduler and may be deprecated shortly. "
+        "Please contact the rubin_scheduler maintainers if "
+        "this is in use elsewhere."
+    )
+    warnings.warn(message, FutureWarning)
 
 
 class BaseBasisFunction:
@@ -251,7 +261,13 @@ class SimpleArrayBasisFunction(BaseBasisFunction):
 
 
 class DelayStartBasisFunction(BaseBasisFunction):
-    """Force things to not run before a given night"""
+    """Force things to not run before a given night.
+
+    Parameters
+    ----------
+    nights_delay : `float`, optional
+        Return False until conditions.night >= nights_delay.
+    """
 
     def __init__(self, nights_delay=365.25 * 5):
         super().__init__()
@@ -363,19 +379,30 @@ class NObsPerYearBasisFunction(BaseBasisFunction):
 
 
 class NGoodSeeingBasisFunction(BaseBasisFunction):
-    """Try to get N "good seeing" images each observing season
+    """Try to get N "good seeing" images each observing season.
 
     Parameters
     ----------
-    seeing_fwhm_max : `float` (0.8)
+    filtername : `str`
+        Bandpass in which to count images. Default r.
+    nside : `int`
+        The nside of the map for the basis function. Should match
+        survey and scheduler nside.
+        Default None uses `set_default_nside`.
+    seeing_fwhm_max : `float`
         Value to consider as "good" threshold (arcsec).
-    m5_penalty_max : `float` (0.5)
-        The maximum depth loss that is considered acceptable (magnitudes)
-    n_obs_desired : `int` (3)
+        Default of 0.8 arcseconds.
+    m5_penalty_max : `float`
+        The maximum depth loss that is considered acceptable (magnitudes),
+        compared to the dark-sky map in this filter.
+        Default 0.5 magnitudes.
+    n_obs_desired : `int`
         Number of good seeing observations to collect per season.
-    mjd_start : float (1)
-        The starting MJD.
-    footprint : `np.array` (None)
+        Default 3.
+    mjd_start : `float`
+        The starting MJD of the survey.
+        Default None uses `rubin_scheduler.utils.survey_start_mjd()`.
+    footprint : `np.array`, (N,)
         Only use area where footprint > 0. Should be a HEALpix map.
         Default None calls `get_current_footprint()`.
     """
@@ -387,20 +414,22 @@ class NGoodSeeingBasisFunction(BaseBasisFunction):
         seeing_fwhm_max=0.8,
         m5_penalty_max=0.5,
         n_obs_desired=3,
+        mjd_start=None,
         footprint=None,
-        mjd_start=1,
     ):
         super().__init__(nside=nside, filtername=filtername)
         self.seeing_fwhm_max = seeing_fwhm_max
         self.m5_penalty_max = m5_penalty_max
         self.n_obs_desired = n_obs_desired
-
+        if mjd_start is None:
+            mjd_start = survey_start_mjd()
+        self.mjd_start = mjd_start
         self.survey_features["N_good_seeing"] = features.NObservationsCurrentSeason(
-            filtername=filtername,
-            mjd_start=mjd_start,
-            seeing_fwhm_max=seeing_fwhm_max,
-            m5_penalty_max=m5_penalty_max,
-            nside=nside,
+            filtername=self.filtername,
+            mjd_start=self.mjd_start,
+            seeing_fwhm_max=self.seeing_fwhm_max,
+            m5_penalty_max=self.m5_penalty_max,
+            nside=self.nside,
         )
         # Set footprint to current survey footprint class if undefined.
         if footprint is None:
@@ -409,7 +438,6 @@ class NGoodSeeingBasisFunction(BaseBasisFunction):
         self.footprint = footprint
         self.result = np.zeros(hp.nside2npix(self.nside))
         self.dark_map = None
-        self.footprint = footprint
 
     def _calc_value(self, conditions, indx=None):
         if self.filtername is not None:
@@ -417,8 +445,10 @@ class NGoodSeeingBasisFunction(BaseBasisFunction):
                 self.dark_map = dark_m5(
                     conditions.dec, self.filtername, conditions.site.latitude_rad, fiducial_FWHMEff=0.7
                 )
-        result = 0
-        # Need to update the feature to the current season
+        # Return the same kind of array (not float) regardless
+        # of result
+        result = self.result.copy()
+        # Update the feature to the current time.
         self.survey_features["N_good_seeing"].season_update(conditions=conditions)
 
         m5_penalty = self.dark_map - conditions.m5_depth[self.filtername]
@@ -429,15 +459,31 @@ class NGoodSeeingBasisFunction(BaseBasisFunction):
             & (self.footprint > 0)
         )[0]
 
-        if np.size(potential_pixels) > 0:
-            result = self.result.copy()
-            result[potential_pixels] = 1
+        result[potential_pixels] = 1
         return result
 
 
 class AvoidLongGapsBasisFunction(BaseBasisFunction):
     """Boost the reward on parts of the survey that haven't been
     observed for a while.
+
+    Parameters
+    ----------
+    filtername : `str`, optional
+        The filter to consider when tracking visits.
+    nside : `int`, optional
+        The nside to use for the basis function.
+        Default None uses `set_default_nside()`.
+    footprint : `np.ndarray`, (N,)
+        The footprint to consider when tracking visits.
+        Default None uses `get_current_footprint()`.
+    min_gap : `float`, optional
+        The minimum gap of time before boosting (in days).
+    max_gap : `float`, optional
+        The maximum gap of time before stopping boosting (in days).
+    ha_limit : `float, optional
+        Only boost visits at parts of the sky with HA < ha_limit
+        (in hours).
     """
 
     def __init__(
@@ -481,7 +527,10 @@ class AvoidLongGapsBasisFunction(BaseBasisFunction):
 
 class TargetMapBasisFunction(BaseBasisFunction):
     """Basis function that tracks number of observations and tries
-    to match a specified spatial distribution
+    to match a specified spatial distribution.
+
+    In general, this is deprecated in favor of
+    `FootprintBasisFunction`.
 
     Parameters
     ----------
@@ -528,25 +577,21 @@ class TargetMapBasisFunction(BaseBasisFunction):
         # Count of all the observations
         self.survey_features["n_obs_count_all"] = features.NObsCount(filtername=None)
         if target_map is None:
-            self.target_map = utils.generate_goal_map(filtername=filtername, nside=self.nside)
+            target_maps, labels = utils.get_current_footprint(self.nside)
+            self.target_map = target_maps[filtername]
         else:
             self.target_map = target_map
         self.out_of_bounds_area = np.where(self.target_map == 0)[0]
         self.out_of_bounds_val = out_of_bounds_val
         self.result = np.zeros(hp.nside2npix(self.nside), dtype=float)
         self.all_indx = np.arange(self.result.size)
+        # As of 4/2024,
+        # this is used in the ts_fbs_utils maintel "anytime" test survey.
+        # It is also used in unit tests.
+        # send_unused_deprecation_warning(self.__class__.__name__)
+        # In general, it is deprecated in favor of FootprintBasisFunction
 
     def _calc_value(self, conditions, indx=None):
-        """
-        Parameters
-        ----------
-        indx : `list` (None)
-            Index values to compute, if None, full map is computed
-
-        Returns
-        -------
-        Healpix reward map
-        """
         result = self.result.copy()
         if indx is None:
             indx = self.all_indx
@@ -572,7 +617,7 @@ def az_rel_point(azs, point_az):
 
 
 class NObsHighAmBasisFunction(BaseBasisFunction):
-    """Reward only reward/count observations at high airmass"""
+    """Reward only reward/count observations at high airmass."""
 
     def __init__(
         self,
@@ -600,16 +645,6 @@ class NObsHighAmBasisFunction(BaseBasisFunction):
         self.out_of_bounds_val = out_of_bounds_val
 
     def add_observation(self, observation, indx=None):
-        """
-        Parameters
-        ----------
-        observation : `np.array`
-            An array with information about the input observation
-        indx : `np.array`
-            The indices of the healpix map that the observation
-            overlaps with
-        """
-
         # Only count the observations if they are at the airmass limits
         if (observation["airmass"] > np.min(self.am_limits)) & (
             observation["airmass"] < np.max(self.am_limits)
@@ -620,10 +655,6 @@ class NObsHighAmBasisFunction(BaseBasisFunction):
                 self.recalc = True
 
     def check_feasibility(self, conditions):
-        """If there is logic to decide if something is feasible
-        (e.g., only if moon is down), it can be calculated here.
-        Helps prevent full __call__ from being called more than needed.
-        """
         result = True
         reward = self._calc_value(conditions)
         # If there are no non-NaN values, we're not feasible now
@@ -675,14 +706,14 @@ class CadenceInSeasonBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
-    drive_map : np.array
+    drive_map : `np.ndarray`, (N,)
         A HEALpix map with values of 1 where the cadence should be driven.
     filtername : `str`
-        The filters that can count
-    season_span : `float` (2.5)
-        How long to consider a spot "in_season" (hours)
-    cadence : `float` (2.5)
-        How long to wait before activating the basis function (days)
+        The filters that can count.
+    season_span : `float`
+        How long to consider a spot "in_season" (hours).
+    cadence : `float`
+        How long to wait before activating the basis function (days).
     """
 
     def __init__(self, drive_map, filtername="griz", season_span=2.5, cadence=2.5, nside=None):
@@ -690,7 +721,7 @@ class CadenceInSeasonBasisFunction(BaseBasisFunction):
         self.drive_map = drive_map
         self.season_span = season_span / 12.0 * np.pi  # To radians
         self.cadence = cadence
-        self.survey_features["last_observed"] = features.Last_observed(nside=nside, filtername=filtername)
+        self.survey_features["last_observed"] = features.LastObserved(nside=nside, filtername=filtername)
         self.result = np.zeros(hp.nside2npix(self.nside), dtype=float)
 
     def _calc_value(self, conditions, indx=None):
@@ -816,6 +847,8 @@ class FootprintNvisBasisFunction(BaseBasisFunction):
         out_of_bounds_val=np.nan,
     ):
         super(FootprintNvisBasisFunction, self).__init__(nside=nside, filtername=filtername)
+        if footprint is None:
+            footprint = np.zeros(hp.nside2npix(self.nside))
         self.footprint = footprint
         self.nvis = nvis
 
@@ -826,6 +859,7 @@ class FootprintNvisBasisFunction(BaseBasisFunction):
         self.result = np.zeros(hp.nside2npix(nside))
         self.result.fill(out_of_bounds_val)
         self.out_of_bounds_val = out_of_bounds_val
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, indx=None):
         result = self.result.copy()
@@ -872,7 +906,7 @@ class ThirdObservationBasisFunction(BaseBasisFunction):
         return result
 
 
-class AvoidFastRevists(BaseBasisFunction):
+class AvoidFastRevisits(BaseBasisFunction):
     """Marks targets as unseen if they are in a specified time window
     in order to avoid fast revisits.
 
@@ -890,7 +924,7 @@ class AvoidFastRevists(BaseBasisFunction):
     """
 
     def __init__(self, filtername="r", nside=None, gap_min=25.0, penalty_val=np.nan):
-        super(AvoidFastRevists, self).__init__(nside=nside, filtername=filtername)
+        super().__init__(nside=nside, filtername=filtername)
 
         self.filtername = filtername
         self.penalty_val = penalty_val
@@ -899,7 +933,7 @@ class AvoidFastRevists(BaseBasisFunction):
         self.nside = nside
 
         self.survey_features = dict()
-        self.survey_features["Last_observed"] = features.Last_observed(filtername=filtername, nside=nside)
+        self.survey_features["Last_observed"] = features.LastObserved(filtername=filtername, nside=nside)
 
     def _calc_value(self, conditions, indx=None):
         result = np.ones(hp.nside2npix(self.nside), dtype=float)
@@ -912,12 +946,20 @@ class AvoidFastRevists(BaseBasisFunction):
 
 
 class NearSunTwilightBasisFunction(BaseBasisFunction):
-    """Reward looking into the twilight for NEOs at high airmass
+    """Reward areas on the sky at high airmass, within 90 degrees azimuth
+    of the Sun, such as suitable for the near-sun twilight microsurvey for
+    near- or interior-to earth asteroids.
 
     Parameters
     ----------
-    max_airmass : `float` (2.5)
-        The maximum airmass to try and observe (unitless)
+    nside : `int`, optional
+        Nside for the basis function. If None, uses `set_default_nside()`.
+    max_airmass : `float`, oprionl
+        The maximum airmass to try and observe (unitless).
+    penalty : `float`, optional
+        The value to fill in non-rewarded parts of the sky.
+        Default np.nan, which serves to mask regions exceeding the airmass
+        limit and more than 90 degrees azimuth toward the sun.
     """
 
     def __init__(self, nside=None, max_airmass=2.5, penalty=np.nan):
@@ -1001,8 +1043,17 @@ class M5DiffBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
-    fiducial_FWHMEff : `float`
-        The zenith seeing to assume for "good" conditions
+    filtername : `str`, optional
+        The filter to consider for visits.
+    fiducial_FWHMEff : `float`, optional
+        The zenith seeing to assume for "good" conditions.
+        While the dark sky depth map simply scales with this value,
+        picking a reasonable fiducial_FWHMEff is important because
+        this effects the overall value and scale of the reward
+        from the basis function.
+    nside : `int`, optional
+        The nside for the basis function.
+        Default None uses `set_default_nside()`.
     """
 
     def __init__(self, filtername="r", fiducial_FWHMEff=0.7, nside=None):
@@ -1017,7 +1068,6 @@ class M5DiffBasisFunction(BaseBasisFunction):
             self.dark_map = dark_m5(
                 conditions.dec, self.filtername, conditions.site.latitude_rad, self.fiducial_FWHMEff
             )
-
         # No way to get the sign on this right the first time.
         result = conditions.m5_depth[self.filtername] - self.dark_map
         return result
@@ -1161,7 +1211,9 @@ class GoalStrictFilterBasisFunction(BaseBasisFunction):
         self.survey_features["Last_observation"] = features.Last_observation()
         self.survey_features["Last_filter_change"] = features.LastFilterChange()
         self.survey_features["n_obs_all"] = features.NObsCount(filtername=None)
+        # Tag is not actually supported at observation level.
         self.survey_features["n_obs"] = features.NObsCount(filtername=filtername, tag=tag)
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def filter_change_bonus(self, time):
         lag_min = self.time_lag_min
@@ -1293,10 +1345,18 @@ class SlewtimeBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
-    max_time : `float` (135)
+    max_time : `float`
          The estimated maximum slewtime (seconds).
          Used to normalize so the basis function spans ~ -1-0
-         in reward units.
+         in reward units. Default 135 seconds corresponds to just
+         slightly less than a filter change.
+    filtername : `str`, optional
+        The filter to check for pre-post slewtime estimates.
+        If a slew includes a filter change, other basis functions will
+        decide on the reward, so the result here can be 0.
+    nside : `int`, optional
+        Nside for the basis function.
+        Default None will use `set_default_nside()`.
     """
 
     def __init__(self, max_time=135.0, filtername="r", nside=None):
@@ -1346,6 +1406,7 @@ class AggressiveSlewtimeBasisFunction(BaseBasisFunction):
         self.hard_max = hard_max
         self.order = order
         self.result = np.zeros(hp.nside2npix(nside), dtype=float)
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, indx=None):
         # If we are in a different filter, the
@@ -1373,17 +1434,22 @@ class AggressiveSlewtimeBasisFunction(BaseBasisFunction):
 
 
 class SkybrightnessLimitBasisFunction(BaseBasisFunction):
-    """Mask regions that are outside a sky brightness limit
-
-    XXX--TODO:  This should probably go to the mask basis functions.
+    """Mask regions that are outside a sky brightness limit.
 
     Parameters
     ----------
-    min : `float` (20.)
-         The minimum sky brightness (mags).
-    max : `float` (30.)
-         The maximum sky brightness (mags).
-
+    nside : `int`, optional
+        The nside for the basis function. Default None uses
+        `set_default_nside()`.
+    filtername : `str`, optional
+        The filter to consider for the skybrightness pre values.
+    sbmin : `float`, optional
+        The minimum (brightest) skybrightness to consider (mags).
+        Default of 20 will cut out some times of night or parts of the
+        sky.
+    sbmax : `float`, optional
+        The maximum (faintest) skybrightness to consider (mags).
+        Default of 30 will pass all skybrightness values.
     """
 
     def __init__(self, nside=None, filtername="r", sbmin=20.0, sbmax=30.0):
@@ -1393,6 +1459,7 @@ class SkybrightnessLimitBasisFunction(BaseBasisFunction):
         self.max = IntRounded(sbmax)
         self.result = np.empty(hp.nside2npix(self.nside), dtype=float)
         self.result.fill(np.nan)
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, indx=None):
         result = self.result.copy()
@@ -1463,6 +1530,7 @@ class CablewrapUnwrapBasisFunction(BaseBasisFunction):
         self.max_duration = max_duration / 60.0 / 24.0  # Convert to days
         self.activation_time = None
         self.result = np.zeros(hp.nside2npix(self.nside), dtype=float)
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, indx=None):
         result = self.result.copy()
@@ -1577,7 +1645,7 @@ class CadenceEnhanceBasisFunction(BaseBasisFunction):
         self.enhance_val = enhance_val
 
         self.survey_features = {}
-        self.survey_features["last_observed"] = features.Last_observed(filtername=filtername)
+        self.survey_features["last_observed"] = features.LastObserved(filtername=filtername)
 
         self.empty = np.zeros(hp.nside2npix(self.nside), dtype=float)
         # No map, try to drive the whole area
@@ -1676,7 +1744,7 @@ class CadenceEnhanceTrapezoidBasisFunction(BaseBasisFunction):
         self.season_limit = season_limit / 12 * np.pi  # To radians
 
         self.survey_features = {}
-        self.survey_features["last_observed"] = features.Last_observed(filtername=filtername)
+        self.survey_features["last_observed"] = features.LastObserved(filtername=filtername)
 
         self.empty = np.zeros(hp.nside2npix(self.nside), dtype=float)
         # No map, try to drive the whole area
@@ -1698,7 +1766,7 @@ class CadenceEnhanceTrapezoidBasisFunction(BaseBasisFunction):
 
         return result
 
-    def season_calc(self, conditions):
+    def season_len(self, conditions):
         ra_mid_season = (conditions.sunRA + np.pi) % (2.0 * np.pi)
         angle_to_mid_season = np.abs(conditions.ra - ra_mid_season)
         over = np.where(IntRounded(angle_to_mid_season) > IntRounded(np.pi))
@@ -1720,7 +1788,7 @@ class CadenceEnhanceTrapezoidBasisFunction(BaseBasisFunction):
             result[ind] += self.suppress_enhance(mjd_diff)
 
         if self.season_limit is not None:
-            radians_to_midseason = self.season_calc(conditions)
+            radians_to_midseason = self.season_len(conditions)
             outside_season = np.where(radians_to_midseason > self.season_limit)
             result[outside_season] = 0
 
@@ -1857,13 +1925,13 @@ class GoodSeeingBasisFunction(BaseBasisFunction):
         nside=None,
         filtername="r",
         footprint=None,
-        fwh_meff_limit=0.8,
+        fwhm_eff_limit=0.8,
         mag_diff=0.75,
     ):
         super(GoodSeeingBasisFunction, self).__init__(nside=nside)
 
         self.filtername = filtername
-        self.fwh_meff_limit = IntRounded(fwh_meff_limit)
+        self.fwhm_eff_limit = IntRounded(fwhm_eff_limit)
         if footprint is None:
             footprints, labels = get_current_footprint(nside=self.nside)
             fp = footprints[self.filtername]
@@ -1874,14 +1942,16 @@ class GoodSeeingBasisFunction(BaseBasisFunction):
 
         self.mag_diff = IntRounded(mag_diff)
         self.survey_features = {}
-        self.survey_features["coadd_depth_all"] = features.Coadded_depth(filtername=filtername, nside=nside)
-        self.survey_features["coadd_depth_good"] = features.Coadded_depth(
-            filtername=filtername, nside=nside, fwh_meff_limit=fwh_meff_limit
+        self.survey_features["coadd_depth_all"] = features.CoaddedDepth(
+            filtername=self.filtername, nside=self.nside
+        )
+        self.survey_features["coadd_depth_good"] = features.CoaddedDepth(
+            filtername=self.filtername, nside=self.nside, fwhm_eff_limit=fwhm_eff_limit
         )
 
     def _calc_value(self, conditions, **kwargs):
         # Seeing is "bad"
-        if IntRounded(conditions.FWHMeff[self.filtername].min()) > self.fwh_meff_limit:
+        if IntRounded(conditions.FWHMeff[self.filtername].min()) > self.fwhm_eff_limit:
             return 0
         result = self.result.copy()
 
@@ -1891,7 +1961,7 @@ class GoodSeeingBasisFunction(BaseBasisFunction):
         # Where are there things we want to observe?
         good_pix = np.where(
             (IntRounded(diff) > self.mag_diff)
-            & (IntRounded(conditions.FWHMeff[self.filtername]) <= self.fwh_meff_limit)
+            & (IntRounded(conditions.FWHMeff[self.filtername]) <= self.fwhm_eff_limit)
         )
         # Hm, should this scale by the mag differences? Probably.
         result[good_pix] = diff[good_pix]
@@ -1905,9 +1975,16 @@ class TemplateGenerateBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
-    day_gap : `float`
-        How long to wait before boosting the reward (days)
-    footprint : `np.array`
+    nside : `int`, optional
+        The nside for the basis function and feature.
+        Default None uses `set_default_nside()`.
+    day_gap : `float`, optional
+        How long to wait before boosting the reward (days).
+        Default of 250 pushes visits into parts of the sky which missed
+        a significant chunk of a season.
+    filtername : `str`, optional
+        The filter to consider when tracking observations.
+    footprint : `np.array`, (N,)
         The indices of the healpixels to apply the boost to.
         Default None will call `get_current_footprint()`.
     """
@@ -1917,7 +1994,7 @@ class TemplateGenerateBasisFunction(BaseBasisFunction):
         self.day_gap = day_gap
         self.filtername = filtername
         self.survey_features = {}
-        self.survey_features["Last_observed"] = features.Last_observed(filtername=filtername)
+        self.survey_features["Last_observed"] = features.LastObserved(filtername=filtername)
         self.result = np.zeros(hp.nside2npix(self.nside))
         if footprint is None:
             footprints, labels = get_current_footprint(self.nside)
@@ -1925,6 +2002,7 @@ class TemplateGenerateBasisFunction(BaseBasisFunction):
         else:
             fp = footprint
         self.out_of_bounds = np.where(fp == 0)
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, **kwargs):
         result = self.result.copy()
@@ -1949,6 +2027,7 @@ class LimitRepeatBasisFunction(BaseBasisFunction):
         self.survey_features["n_obs"] = features.NObsNight(nside=nside, filtername=filtername)
 
         self.result = np.zeros(hp.nside2npix(self.nside))
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, **kwargs):
         result = self.result.copy()
@@ -1971,6 +2050,7 @@ class ObservedTwiceBasisFunction(BaseBasisFunction):
         self.survey_features["n_obs_all"] = features.NObsNight(nside=nside, filtername="")
 
         self.result = np.zeros(hp.nside2npix(self.nside))
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, **kwargs):
         result = self.result.copy()
@@ -2037,12 +2117,15 @@ class VisitGap(BaseBasisFunction):
 
 
 class AvoidDirectWind(BaseBasisFunction):
-    """Basis function to avoid direct wind.
+    """Mask the sky where the wind pressure exceeds `wind_speed_maximum`.
 
     Parameters
     ----------
-    wind_speed_maximum : `float`
+    wind_speed_maximum : `float`, optional
         Wind speed to mark regions as unobservable (in m/s).
+    nside : `int`, optional
+        The nside for the basis function. Default None uses
+        `set_default_nside()`.
     """
 
     def __init__(self, wind_speed_maximum=20.0, nside=None):

--- a/rubin_scheduler/scheduler/basis_functions/feasibility_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/feasibility_funcs.py
@@ -30,11 +30,13 @@ from rubin_scheduler.scheduler.utils import IntRounded
 
 
 class FilterLoadedBasisFunction(BaseBasisFunction):
-    """Check that the filter(s) needed are loaded
+    """Check that the filter(s) needed are loaded.
+
+    Are the filters in `filternames` loaded and available?
 
     Parameters
     ----------
-    filternames : str or list of str
+    filternames : `str` or `list` [ `str` ]
         The filternames that need to be mounted to execute.
     """
 
@@ -53,8 +55,12 @@ class FilterLoadedBasisFunction(BaseBasisFunction):
 
 
 class SunHighLimitBasisFunction(BaseBasisFunction):
-    """Only execute if the sun is high. Have a sum alt limit for sunset,
-    and a time until 12 degree twilight for sun rise.
+    """Only execute if the sun is higher than `sun_alt_limit`,
+    the current time is within `time_to_12deg` of -12 degree twilight,
+    and there is at least `time_remaining` time left before -12 degree
+    twilight.
+
+    Is the current time and sun altitude close to twilight, but not too close?
 
     Parameters
     ----------
@@ -67,6 +73,11 @@ class SunHighLimitBasisFunction(BaseBasisFunction):
     time_remaining : `float`
         Minimum about of time that must be available before trying to
         execute (minutes)
+
+    Notes
+    -----
+    This is primarily useful for surveys which must execute within close
+    limits of -12 degree twilight.
     """
 
     def __init__(self, sun_alt_limit=-14.8, time_to_12deg=21.0, time_remaining=15.0):
@@ -99,7 +110,7 @@ class OnceInNightBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
-    notes : list of str
+    notes : `list` [ `str` ]
         A list of str to check if any observations with a matching note exist.
     """
 

--- a/rubin_scheduler/scheduler/basis_functions/rolling_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/rolling_funcs.py
@@ -11,6 +11,17 @@ import numpy as np
 
 from rubin_scheduler.scheduler import features, utils
 from rubin_scheduler.scheduler.basis_functions import BaseBasisFunction
+from rubin_scheduler.scheduler.utils import ConstantFootprint
+
+
+def send_unused_deprecation_warning(name):
+    message = (
+        f"The basis function {name} is not in use by the current "
+        "baseline scheduler and may be deprecated shortly. "
+        "Please contact the rubin_scheduler maintainers if "
+        "this is in use elsewhere."
+    )
+    warnings.warn(message, FutureWarning)
 
 
 class FootprintBasisFunction(BaseBasisFunction):
@@ -18,17 +29,20 @@ class FootprintBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
-    filtername : str ('r')
-        The filter for this footprint
-    footprint : rubin_scheduler.scheduler.utils.Footprint object
-        The desired footprint.
-    all_footprints_sum : float (None)
-        If using multiple filters, the sum of all the footprints. Needed
-        to make sure basis functions are normalized properly across all
-        fitlers.
-    out_of_bounds_val : float (-10)
+    filtername : `str`, optional
+        The filter for this footprint. Default r.
+    nside : `int`, optional
+        The nside for the basis function and features.
+        Default None uses `~utils.set_default_nside()`
+    footprint : `~rubin_scheduler.scheduler.utils.Footprint` object
+        The desired footprint. The default will set this to None,
+        but in general this is really not desirable.
+        In order to make default a kwarg, a current baseline footprint
+        is setup with a Constant footprint (not rolling, not even season
+        aware).
+    out_of_bounds_val : `float`, optional
         The value to set the basis function for regions that are not in
-        the footprint (default -10, np.nan is another good value to use)
+        the footprint. Default -10, np.nan is another good value to use.
 
     """
 
@@ -38,15 +52,23 @@ class FootprintBasisFunction(BaseBasisFunction):
         nside=None,
         footprint=None,
         out_of_bounds_val=-10.0,
-        window_size=6.0,
     ):
-        super(FootprintBasisFunction, self).__init__(nside=nside, filtername=filtername)
+        super().__init__(nside=nside, filtername=filtername)
+        if footprint is None:
+            # This is useful as a backup, but really footprint SHOULD
+            # be specified when basis function is set up.
+            # This just uses whole survey, but doesn't set up rolling.
+            warnings.warn("No Footprint set, using a constant default.")
+            target_maps, labels = utils.get_current_footprint(self.nside)
+            fp = ConstantFootprint(nside=self.nside)
+            for f in "ugrizy":
+                fp.set_footprint(f, target_maps[f])
         self.footprint = footprint
 
         self.survey_features = {}
         # All the observations in all filters
-        self.survey_features["N_obs_all"] = features.NObservations(nside=nside, filtername=None)
-        self.survey_features["N_obs"] = features.NObservations(nside=nside, filtername=filtername)
+        self.survey_features["N_obs_all"] = features.NObservations(nside=self.nside, filtername=None)
+        self.survey_features["N_obs"] = features.NObservations(nside=self.nside, filtername=filtername)
 
         # should probably actually loop over all the target maps?
         self.out_of_bounds_area = np.where(footprint.get_footprint(self.filtername) <= 0)[0]
@@ -100,7 +122,6 @@ class FootprintRollingBasisFunction(BaseBasisFunction):
         season_length=365.25,
         max_season=None,
         day_offset=None,
-        window_size=6.0,
     ):
         super(FootprintRollingBasisFunction, self).__init__(nside=nside, filtername=filtername)
 
@@ -329,7 +350,8 @@ class TargetMapModuloBasisFunction(BaseBasisFunction):
             season_length=season_length,
         )
         if target_maps is None:
-            self.target_maps = utils.generate_goal_map(filtername=filtername, nside=self.nside)
+            target_maps, labels = utils.get_current_footprint(nside)
+            self.target_map = target_maps[filtername]
         else:
             self.target_maps = target_maps
         # should probably actually loop over all the target maps?
@@ -347,6 +369,7 @@ class TargetMapModuloBasisFunction(BaseBasisFunction):
         self.season_modulo = season_modulo
         self.max_season = max_season
         self.season_length = season_length
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, indx=None):
         """

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -256,8 +256,9 @@ class Conditions:
         # Keep these named in both ways, for backwards compatibility for now
         if season_map is None:
             season_map = calc_season(np.degrees(self.ra), [self.mjd_start], self.mjd_start).flatten()
-        # season_offset in units of days
+        # season_offset in units of days -useful for season_calc calculations
         self.season_offset = season_map * 365.25
+        # Season_map is useful for utils.calc_season calculations
         self.season_map = season_map
 
         self.sun_ra_start = sun_ra_start
@@ -602,10 +603,6 @@ class Conditions:
         print("moonPhase: ", self.moon_phase, "  ", file=output)
         print("bulk_cloud: ", self.bulk_cloud, "  ", file=output)
         print("targets_of_opportunity: ", self.targets_of_opportunity, "  ", file=output)
-        print("season_modulo: ", self.season_modulo, "  ", file=output)
-        print("season_max_season: ", self.season_max_season, "  ", file=output)
-        print("season_length: ", self.season_length, "  ", file=output)
-        print("season_floor: ", self.season_floor, "  ", file=output)
         print("cumulative_azimuth_rad: ", self.cumulative_azimuth_rad, "  ", file=output)
 
         positions = [

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -8,12 +8,7 @@ import healpy as hp
 import numpy as np
 import pandas as pd
 
-from rubin_scheduler.scheduler.utils import (
-    match_hp_resolution,
-    season_calc,
-    set_default_nside,
-    smallest_signed_angle,
-)
+from rubin_scheduler.scheduler.utils import match_hp_resolution, set_default_nside, smallest_signed_angle
 from rubin_scheduler.utils import (
     Site,
     _angular_separation,
@@ -21,19 +16,49 @@ from rubin_scheduler.utils import (
     _approx_ra_dec2_alt_az,
     _hpid2_ra_dec,
     calc_lmst,
+    calc_season,
     m5_flat_sed,
+    survey_start_mjd,
 )
 
 
 class Conditions:
-    """
-    Class to hold telemetry information
+    """Holds telemetry information, keeping calculated values in sync
+    for `self.mjd` (such as ra/dec mappings to alt/az).
 
-    If the incoming value is a healpix map, we use a setter to ensure the
-    resolution matches.
+    Incoming values have setters to keep values in sync. Healpix maps
+    are set to the expected (`self.nside`) resolution.
 
     Unless otherwise noted, all values are assumed to be valid at the time
-    given by self.mjd
+    given by `self.mjd`.
+
+    Parameters
+    ----------
+    nside : `int`, optional
+        The healpixel nside to set the resolution of attributes.
+        Default of None will use
+        `rubin_scheduler.scheduler.utils.set_default_nside`.
+    site : str ('LSST')
+        A site name used to create a sims.utils.Site object. For
+        looking up observatory parameters like latitude and longitude.
+    exptime : `float`, optional
+        The exposure time (seconds) to assume when computing the 5-sigma
+        limiting depth maps stored in Conditions. These maps are used
+        by basis functions, but are not used to calculate expected
+        observation m5 values (such as when exposure time varies).
+        Default 30 seconds.
+    mjd_start : `float`, optional
+        The starting MJD of the survey. Default uses
+        `rubin_scheduler.utils.survey_start_date()`.
+    season_map : `np.array`, (N,), optional
+        A HEALpix array that specifies the day offset when computing
+        the season for each HEALpix. Equivalent to season at mjd_start.
+    sun_ra_start : `float`, optional
+        The RA of the sun at the start of the survey (radians)
+    mjd : `float`, optional
+        The current MJD.
+        Default of None is fine on init - will be updated by telemetry
+        stream.
     """
 
     global_maps = set(["ra", "dec", "slewtime", "airmass", "zeros_map", "nan_map"])
@@ -44,32 +69,12 @@ class Conditions:
         nside=None,
         site="LSST",
         exptime=30.0,
-        mjd_start=59853.5,
-        season_offset=None,
+        mjd_start=survey_start_mjd(),
+        season_map=None,
         sun_ra_start=None,
         mjd=None,
     ):
         """
-        Parameters
-        ----------
-        nside : int
-            The healpixel nside to set the resolution of attributes.
-        site : str ('LSST')
-            A site name used to create a sims.utils.Site object. For
-            looking up observatory paramteres like latitude and longitude.
-        expTime : float (30)
-            The exposure time to assume when computing the 5-sigma
-            limiting depth
-        mjd_start : float (59853.5)
-            The starting MJD of the survey.
-        season_offset : np.array
-            A HEALpix array that specifies the day offset when computing
-            the season for each HEALpix.
-        sun_ra_start : float (None)
-            The RA of the sun at the start of the survey (radians)
-        mjd : float
-            The current MJD.
-
         Attributes (Set on init)
         -----------
         nside : int
@@ -204,6 +209,11 @@ class Conditions:
         pa : np.array
             The parallactic angle of each healpixel (radians). Recaclulated
             if mjd is updated. Based on the fast approximate alt,az values.
+        season : `np.array`, (N,)
+            The current season value (0-1) at each healpixel.
+            Recalculated if mjd is updated. Used by features that would
+            otherwise need to calculate `season`.
+            Uses `rubin_scheduler.utils.calc_season`.
         lmst : float
             The local mean sidearal time (hours). Updates is mjd is changed.
         m5_depth : dict of np.array
@@ -233,24 +243,36 @@ class Conditions:
         if nside is None:
             nside = set_default_nside()
         self.nside = nside
+
+        # The RA, Dec grid we are using
+        hpids = np.arange(hp.nside2npix(self.nside))
+        self.ra, self.dec = _hpid2_ra_dec(self.nside, hpids)
+
         self.site = Site(site)
         self.exptime = exptime
-        self.mjd_start = mjd_start
-        hpids = np.arange(hp.nside2npix(nside))
-        self.season_offset = season_offset
-        self.sun_ra_start = sun_ra_start
-        # Generate an empty map so we can copy when we need a new map
-        self.zeros_map = np.zeros(hp.nside2npix(nside), dtype=float)
-        self.nan_map = np.zeros(hp.nside2npix(nside), dtype=float)
-        self.nan_map.fill(np.nan)
-        # The RA, Dec grid we are using
-        self.ra, self.dec = _hpid2_ra_dec(nside, hpids)
 
+        self.mjd_start = mjd_start
+
+        # Keep these named in both ways, for backwards compatibility for now
+        if season_map is None:
+            season_map = calc_season(np.degrees(self.ra), [self.mjd_start], self.mjd_start).flatten()
+        # season_offset in units of days
+        self.season_offset = season_map * 365.25
+        self.season_map = season_map
+
+        self.sun_ra_start = sun_ra_start
+
+        # Generate an empty map so we can copy when we need a new map
+        self.zeros_map = np.zeros(hp.nside2npix(self.nside), dtype=float)
+        self.nan_map = np.zeros(hp.nside2npix(self.nside), dtype=float)
+        self.nan_map.fill(np.nan)
+
+        # Set other attributes to Nones
         self._init_attributes()
         self.mjd = mjd
 
     def _init_attributes(self):
-        """Initialize all the attributes"""
+        """Initialize or clear all the attributes"""
 
         # Modified Julian Date (day)
         self._mjd = None
@@ -258,6 +280,7 @@ class Conditions:
         self._alt = None
         self._az = None
         self._pa = None
+
         # The cloud level. Fraction, but could upgrade to transparency map
         self.clouds = None
         self._slewtime = None
@@ -274,7 +297,7 @@ class Conditions:
         self.wind_speed = None
         self.wind_direction = None
 
-        # Upcomming scheduled observations
+        # Upcoming scheduled observations
         self.scheduled_observations = np.array([], dtype=float)
 
         # Attribute to hold the current observing queue
@@ -327,12 +350,11 @@ class Conditions:
 
         self.targets_of_opportunity = None
 
+        # self._season tracks the actual current
+        # observing season at each pixel
         self._season = None
-
-        self.season_modulo = None
-        self.season_max_season = None
-        self.season_length = 365.25
-        self.season_floor = True
+        # int_season = np.floor(season)
+        self._int_season = None
 
         # Potential attributes that get computed
         self._solar_elongation = None
@@ -419,6 +441,22 @@ class Conditions:
             self.site.longitude_rad,
             self._mjd,
         )
+
+    @property
+    def season(self):
+        if self._season is None:
+            self.update_season()
+        return self._season
+
+    @property
+    def int_season(self):
+        if self._int_season is None:
+            self.update_season()
+        return self._int_season
+
+    def update_season(self):
+        self._season = self.season_map + (self.mjd - self.mjd_start) / 365.25
+        self._int_season = np.floor(self._season)
 
     @functools.lru_cache(maxsize=10)
     def future_alt_az(self, mjd):
@@ -518,35 +556,6 @@ class Conditions:
         if self._az_to_antisun is None:
             self.calc_az_to_antisun()
         return self._az_to_antisun
-
-    # XXX, there's probably an elegant decorator that could do this
-    # caching automatically
-    def season(self, modulo=None, max_season=None, season_length=365.25, floor=True):
-        if self.season_offset is not None:
-            kwargs_match = (
-                (modulo == self.season_modulo)
-                & (max_season == self.season_max_season)
-                & (season_length == self.season_length)
-                & (floor == self.season_floor)
-            )
-            if ~kwargs_match:
-                self.season_modulo = modulo
-                self.season_max_season = max_season
-                self.season_length = season_length
-                self.season_floor = floor
-            if (self._season is None) | (~kwargs_match):
-                self._season = season_calc(
-                    self.night,
-                    offset=self.season_offset,
-                    modulo=modulo,
-                    max_season=max_season,
-                    season_length=season_length,
-                    floor=floor,
-                )
-        else:
-            self._season = None
-
-        return self._season
 
     def __repr__(self):
         return f"<{self.__class__.__name__} mjd_start='{self.mjd_start}' at {hex(id(self))}>"

--- a/rubin_scheduler/scheduler/features/features.py
+++ b/rubin_scheduler/scheduler/features/features.py
@@ -464,8 +464,33 @@ class LastNObsTimes(BaseSurveyFeature):
 
 
 class NObservationsCurrentSeason(BaseSurveyFeature):
-    """Track how many observations have been taken in the current season
-    that meet criteria.
+    """Count the observations at each healpix, taken in the most
+    recent season, that meet filter, seeing and m5 criteria.
+
+    Useful for ensuring that "good quality" observations are acquired
+    in each season at each point in the survey footprint.
+
+    Parameters
+    ----------
+    filtername : `str`, optional
+        If None (default) count observations in any filter.
+        Otherwise, only count observations in the specified filter.
+    nside : `int`, optional
+        If None (default), use default nside for scheduler.
+        Otherwise, set nside for the map to nside.
+    seeing_fwhm_max : `float`, optional
+        If None (default), count observations up to any seeing value.
+        Otherwise, only count observations with better seeing (`FWHMeff`)
+        than `seeing_fwhm_max`. In arcseconds.
+    m5_penalty_max : `float`, optional
+        If None (default), count observations with any m5 value.
+        Otherwise, only count observations within this value of the
+        dark sky map at this pixel.
+        Only relevant if filtername is not None.
+    mjd_start : `float`, optional
+        If None, uses default survey_start_mjd for the start of the survey.
+        This defines the starting year for counting seasons, so should
+        be the start of the survey.
     """
 
     def __init__(
@@ -474,89 +499,188 @@ class NObservationsCurrentSeason(BaseSurveyFeature):
         nside=None,
         seeing_fwhm_max=None,
         m5_penalty_max=None,
-        mjd_start=1,
+        mjd_start=None,
     ):
-        self.filtername = filtername
         if nside is None:
-            self.nside = utils.set_default_nside()
-        else:
-            self.nside = nside
+            nside = utils.set_default_nside()
+        self.nside = nside
         self.seeing_fwhm_max = seeing_fwhm_max
+        self.filtername = filtername
         self.m5_penalty_max = m5_penalty_max
+        # If filtername not set, then we can't set m5_penalty_max.
+        if self.filtername is None and self.m5_penalty_max is not None:
+            warnings.warn("To use m5_penalty_max, filtername must be set. Disregarding m5_penalty_max.")
+            self.m5_penalty_max = None
 
-        self.feature = np.zeros(hp.nside2npix(nside), dtype=float)
+        # Get the dark sky map
         if self.filtername is not None:
             self.dark_map = dark_sky(nside)[filtername]
         self.ones = np.ones(hp.nside2npix(self.nside))
+
+        if mjd_start is None:
+            mjd_start = survey_start_mjd()
+        self.mjd_start = mjd_start
+
+        # Set up feature values - this includes the count in a given season
+        # Find the healpixels for each point on the sky
         self.ra, self.dec = _hpid2_ra_dec(nside, np.arange(hp.nside2npix(nside)))
-        self.season_map = calc_season(np.degrees(self.ra), mjd_start)
+        self.ra_deg = np.degrees(self.ra)
+
+        self.mjd = mjd_start
+        # Set up season_map. This should be the same as conditions.season_map
+        # but the important thing is that mjd_start matches.
+        self.season_map = calc_season(self.ra_deg, [self.mjd], self.mjd_start).flatten()
+        self.season = np.floor(self.season_map)
+
+        self.feature = np.zeros(hp.nside2npix(nside), dtype=float)
+        # Set bins for add_observations_array
         self.bins = np.arange(hp.nside2npix(nside) + 1) - 0.5
 
     def season_update(self, observation=None, conditions=None):
-        """clear the map anywhere the season has rolled over"""
-        if observation is not None:
-            current_season = calc_season(np.degrees(self.ra), observation["mjd"])
-        if conditions is not None:
-            current_season = calc_season(np.degrees(self.ra), conditions.mjd)
+        """Update the season_map to the current time.
 
-        # If the season has changed anywhere, set that count to zero
-        new_season = np.where((self.season_map - current_season) != 0)
-        self.feature[new_season] = 0
-        self.season_map = current_season
+        This assumes time increases monotonically in the conditions or
+        observations objects passed as arguments.
+        Using the 'mjd' from the conditions, where parts of the sky
+        have changed season (increasing in the `self.season_map` + 1)
+        the `self.feature` is cleared, in order to restart counting
+        observations in the new season.
+
+        Parameters
+        ----------
+        observation : `np.array`, (1,N)
+            Array of observation information, containing
+            `mjd` for the time. See
+            `rubin_scheduler.scheduler.utils.empty_observation`.
+        conditions : `rubin_scheduler.scheduler.Conditions`, optional
+            A conditions object, containing `mjd`.
+
+        Notes
+        -----
+        One of observations or conditions must be passed, but either
+        are options so this can be used with add_observation.
+        Most of the time, the updates will come from `conditions`.
+        """
+        mjd_now = None
+        mjd_from = None
+        if observation is not None:
+            mjd_now = observation["mjd"]
+            mjd_from = "observation"
+        # Prefer to use Conditions for the time.
+        if conditions is not None:
+            mjd_now = conditions.mjd
+            mjd_from = "conditions"
+        if mjd_now is None:
+            warnings.warn(
+                "Expected either a conditions or observations object. Not updating season_map.",
+                UserWarning,
+            )
+            return
+        if isinstance(mjd_now, np.ndarray) or isinstance(mjd_now, list):
+            mjd_now = mjd_now[0]
+        # Check that time doesn't go backwards.
+        # But only bother to warn if it's coming from conditions.
+        # Observations may look like they go backwards.
+        if mjd_now < self.mjd:
+            if mjd_from == "conditions":
+                warnings.warn(
+                    f"Time must flow forwards to track the "
+                    f"feature in {self.__class__.__name__}."
+                    f"Not updating season_map.",
+                    UserWarning,
+                )
+            # But just return without update in either case.
+            return
+        # Calculate updated season values.
+        updated_season = np.floor(self.season_map + (mjd_now - self.mjd_start) / 365.25)
+        # Clear feature where season increased by 1 (note 'floor' above).
+        self.feature[np.where(updated_season > self.season)] = 0
+        # Update to new time and season.
+        self.mjd = mjd_now
+        self.season = updated_season
 
     def add_observations_array(self, observations_array, observations_hpid):
+        # Update self.season to the most recent observation time
         self.season_update(observation=observations_array[-1])
 
-        check1 = np.zeros(observations_array.size, dtype=bool)
+        # Start assuming 'check' is all True, for all observations.
+        check = np.ones(observations_array.size, dtype=bool)
+
+        # Rule out the observations with seeing fwhmeff > limit
         if self.seeing_fwhm_max is not None:
-            check1[np.where(observations_array["FWHMeff"] <= self.seeing_fwhm_max)] = True
-        else:
-            check1[:] = True
+            check[np.where(observations_array["FWHMeff"] > self.seeing_fwhm_max)] = False
 
-        check2 = np.zeros(observations_array.size, dtype=bool)
+        # Rule out observations which are not in the desired filter
+        if self.filtername is not None:
+            check[np.where(observations_array["filter"] != self.filtername)] = False
+
+        # Convert the "check" array on observations_array into a
+        # "check" array on the hpids so we can evaluate healpix-level items
+        check_hpid_indxs = np.in1d(observations_hpid["ID"], observations_array["ID"][check])
+        # Set up a new valid/not valid flag, now on observations_hpid
+        check_hp = np.zeros(len(observations_hpid), dtype=bool)
+        # Set all observations which passed simpler tests above to True
+        check_hp[check_hpid_indxs] = True
+
+        hpids = observations_hpid["hpid"]
+
+        # This could be done once per observation, but to make life
+        # easier for index matching, let's just calculate season
+        # based on the hpid array.
+        # We only want to count observations that would fall within the
+        # current season, so calculate the season for each obs.
+        seasons = np.floor(
+            calc_season(
+                np.degrees(observations_hpid["RA"]),
+                observations_hpid["mjd"],
+                self.mjd_start,
+                calc_diagonal=True,
+            )
+        )
+        season_change = self.season[hpids] - seasons
+        check_hp = np.where(season_change != 0, False, check_hp)
+        # And check for m5_penalty_map
         if self.m5_penalty_max is not None:
-            hpid = ra_dec2_hpid(self.nside, observations_array["RA"], observations_array["dec"])
-            penalty = self.dark_map[hpid] - observations_array["fivesigmadepth"]
-            check2[np.where(penalty <= self.m5_penalty_max)] = True
-        else:
-            check2[:] = True
+            penalty = self.dark_map[hpids] - observations_hpid["fivesigmadepth"]
+            check_hp = np.where(penalty > self.m5_penalty_max, False, check_hp)
 
-        if self.filtername is None:
-            check3 = np.zeros(observations_array.size, dtype=bool)
-            check3[np.where(observations_array["filter"] == self.filter)] = True
-        else:
-            check3 = np.ones(observations_array.size, dtype=bool)
-
-        good_ids = observations_array[check1 & check2 % check3]["ID"]
-
-        indx = np.in1d(observations_hpid["ID"], observations_array["ID"][good_ids])
-
+        # Bin up the observations per hpid and add them to the feature.
         result, _be, _bn = binned_statistic(
-            observations_hpid["hpid"][indx],
-            observations_hpid["hpid"][indx],
+            observations_hpid["hpid"][check_hp],
+            observations_hpid["hpid"][check_hp],
             bins=self.bins,
             statistic=np.size,
         )
+        # Add the resulting observations to feature.
         self.feature += result
 
-    def add_observation(self, observation, indx=None):
+    def add_observation(self, observation, indx):
+        # Update the season map to the current time.
         self.season_update(observation=observation)
+        # Check if *this* observation is in the current season
+        # (This means we could add observations from the past, but
+        # would count it against the current season).
+        season_obs = np.floor(self.season_map[indx] + (observation["mjd"] - self.mjd_start) / 365.25)
+        this_season_indx = np.array(indx)[np.where(season_obs == self.season[indx])]
 
+        # Check if seeing is good enough.
         if self.seeing_fwhm_max is not None:
-            check1 = observation["FWHMeff"] <= self.seeing_fwhm_max
+            check = observation["FWHMeff"] <= self.seeing_fwhm_max
         else:
-            check1 = True
+            check = True
 
-        if self.m5_penalty_max is not None:
-            hpid = ra_dec2_hpid(self.nside, observation["RA"], observation["dec"])
-            penalty = self.dark_map[hpid] - observation["fivesigmadepth"]
-            check2 = penalty <= self.m5_penalty_max
-        else:
-            check2 = True
+        # Check if observation is in the right filter
+        if self.filtername is not None and check:
+            if observation["filter"] != self.filtername:
+                check = False
+            else:
+                # Check if observation in correct filter and deep enough.
+                if self.m5_penalty_max is not None:
+                    penalty = self.dark_map[this_season_indx] - observation["fivesigmadepth"]
+                    this_season_indx = this_season_indx[np.where(penalty <= self.m5_penalty_max)]
 
-        if check1 & check2:
-            if self.filtername is None or observation["filter"][0] in self.filtername:
-                self.feature[indx] += 1
+        if check:
+            self.feature[this_season_indx] += 1
 
 
 class CoaddedDepth(BaseSurveyFeature):

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -1,5 +1,6 @@
 __all__ = ("ModelObservatory",)
 
+import warnings
 
 import healpy as hp
 import numpy as np
@@ -10,13 +11,14 @@ import rubin_scheduler.skybrightness_pre as sb
 from rubin_scheduler.data import data_versions
 from rubin_scheduler.scheduler.features import Conditions
 from rubin_scheduler.scheduler.model_observatory import KinemModel
-from rubin_scheduler.scheduler.utils import create_season_offset, set_default_nside
+from rubin_scheduler.scheduler.utils import set_default_nside
 
 # For backwards compatibility
-from rubin_scheduler.site_models import Almanac, CloudData
-from rubin_scheduler.site_models import ConstantCloudData as NoClouds
-from rubin_scheduler.site_models import ConstantSeeingData as NominalSeeing
 from rubin_scheduler.site_models import (
+    Almanac,
+    CloudData,
+    ConstantCloudData,
+    ConstantSeeingData,
     ScheduledDowntimeData,
     SeeingData,
     SeeingModel,
@@ -27,119 +29,147 @@ from rubin_scheduler.utils import (
     _angular_separation,
     _approx_altaz2pa,
     _approx_ra_dec2_alt_az,
+    _hpid2_ra_dec,
     _ra_dec2_hpid,
     calc_lmst,
+    calc_season,
     m5_flat_sed,
     survey_start_mjd,
 )
 
 
 class ModelObservatory:
-    """A class to generate a realistic telemetry stream for the scheduler"""
+    """Generate a realistic telemetry stream for the scheduler in simulations,
+    including simulating the acquisition of observations.
+
+    Parameters
+    ----------
+    nside : `int`, optional
+        The healpix nside resolution.
+        Default None uses `set_default_nside()`.
+    mjd : `float`, optional
+        The MJD to start the model observatory for observations.
+        Used to set current conditions and load sky.
+        Default None uses mjd_start.
+    mjd_start : `float`, optional
+        The MJD of the start of the survey.
+        This must be set to start of whole survey, for tracking
+        purposes.  Default None uses `survey_start_mjd()`.
+    alt_min : `float`, optional
+        The minimum altitude to compute models at (degrees).
+    lax_dome : `bool`, optional
+        Passed to observatory model. If true, allows dome creep.
+    cloud_limit : `float`, optional.
+        The limit to stop taking observations if the cloud model returns
+        something equal or higher. Default of 0.3 is validated as a
+        "somewhat pessimistic" weather downtime choice.
+    sim_to_o : `sim_targetoO` object, optional
+        If one would like to inject simulated ToOs into the telemetry
+        stream. Default None adds no ToOs.
+    park_after : `float`, optional
+        Park the telescope after a gap longer than park_after (minutes).
+        Default 10 minutes is used to park the telescope during downtime.
+    init_load_length : `int`, optional
+        The length of pre-scheduled sky brightness values to load
+        initially (days). The default is 10 days; shorter values
+        can be used for quicker load times.
+    kinem_model : `~.scheduler.model_observatory.Kinem_model`, optional
+        An instantiated rubin_scheduler Kinem_model object.
+        Default of None uses a default Kinem_model.
+    seeing_db : `str`, optional
+        The filename of the seeing data database, if one would like
+        to use an alternate seeing database.
+        Default None uses the default seeing database.
+    seeing_data : `~.site_models.SeeingData`-like, optional
+        If one wants to replace the default seeing_data object.
+        Should be an object with a
+        __call__ method that takes MJD and returns zenith fwhm_500 in
+        arcsec. Set to "ideal" to have constant 0.7" seeing.
+    cloud_db : `str`, optional
+        The filename of the cloud data database.
+        Default of None uses the default database from rubin_sim_data.
+    cloud_offset_year : `int`, optional
+        The year offset to be passed to CloudData. Default 0.
+    cloud_data : `~.site_models.CloudData`-like, optional
+        If one wants to replace the default cloud data. Should be an
+        object with a __call__ method that takes MJD and returns
+        cloudy level. Set to "ideal" for  no clouds.
+    downtimes : `np.ndarray`, (N,3) or None, optional
+        If one wants to replace the default downtimes. Should be a
+        np.array with columns of "start" and "end" with MJD values
+        and should include both scheduled and unscheduled downtime.
+        Set to "ideal" for no downtime. Default of None will use
+        the downtime models from `~.site_models.ScheduledDowntime`
+        and `~.site_models.UnscheduledDowntime`.
+    no_sky : `bool`, optional
+        If True, then don't load any skybrightness files.
+        Handy if one wants a well filled out Conditions object,
+        but doesn't need the sky since that can be slower to load.
+        Default False.
+    wind_data : ~.site_models.WindData`-like, optional
+        If one wants to replace the default wind_data object. Should
+        be an object with a __call__ method that takes the time and
+        returns a tuple with the wind speed (m/s) and originating
+        direction (radians east of north).
+        Default of None uses an idealized WindData object with no wind.
+    starting_time_key : `str`, optional
+        What key in the almanac to use to determine the start of
+        observing on a night. Default "sun_n12_setting", e.g., sun
+        at -12 degrees and setting. Other options are
+        "sun_n18_setting" and "sunset".
+        If surveys are not configured to wait until the sun is lower
+        in the sky, observing will start as soon as the time passes
+        the time returned by this key, in each night.
+    ending_time_key : `str`, optional
+        What key in the almanac to use to signify it is time to skip
+        to the next night. Default "sun_n12_rising", e.g., sun at
+        -12 degrees and rising. Other options are "sun_n18_rising"
+        and "sunrise".
+    """
 
     def __init__(
         self,
         nside=None,
+        mjd=None,
         mjd_start=None,
         alt_min=5.0,
         lax_dome=True,
         cloud_limit=0.3,
         sim_to_o=None,
-        seeing_db=None,
         park_after=10.0,
         init_load_length=10,
         kinem_model=None,
+        seeing_db=None,
+        seeing_data=None,
         cloud_db=None,
         cloud_offset_year=0,
         cloud_data=None,
-        seeing_data=None,
         downtimes=None,
         no_sky=False,
         wind_data=None,
         starting_time_key="sun_n12_setting",
         ending_time_key="sun_n12_rising",
     ):
-        """
-        Parameters
-        ----------
-        nside : int (None)
-            The healpix nside resolution
-        mjd_start : float (None)
-            The MJD to start the observatory up at. Uses util to lookup
-            default if None.
-        alt_min : float (5.)
-            The minimum altitude to compute models at (degrees).
-        lax_dome : bool (True)
-            Passed to observatory model. If true, allows dome creep.
-        cloud_limit : float (0.3)
-            The limit to stop taking observations if the cloud model returns
-            something equal or higher
-        sim_to_o : sim_targetoO object (None)
-            If one would like to inject simulated ToOs into the telemetry
-            stream.
-        seeing_db : filename of the seeing data database (None)
-            If one would like to use an alternate seeing database
-        park_after : float (10)
-            Park the telescope after a gap longer than park_after (minutes)
-        init_load_length : int (10)
-            The length of pre-scheduled sky brighntess to load initially
-            (days).
-        kinem_model : kinematic model object (None)
-            A instantiated
-            rubin_scheduler.scheduler.model_observatory.Kinem_model
-            object. If None, the default is used
-        cloud_db : str (None)
-            The file to use for clouds. Default of None uses the database in
-            rubin_sim_data.
-        cloud_offset_year : 0
-            The year offset to be passed to CloudData.
-        cloud_data : None
-            If one wants to replace the default cloud data. Should be an
-            object with a __call__ method that takes MJD and returns
-            cloudy level. Set to "ideal" for  no clouds.
-        seeing_data : None
-            If one wants to replace the default seeing_data object.
-            Should be an object with a
-            __call__ method that takes MJD and returns zenith fwhm_500 in
-            arcsec. Set to "ideal" to have constant 0.7" seeing.
-        downtimes : None
-            If one wants to replace the default downtimes. Should be a
-            np.array with columns of "start" and "end" with MJD values
-            and should include both scheduled and unscheduled downtime.
-            Set to "ideal" for no downtime.
-        no_sky : bool
-            Don't bother loading sky files. Handy if one wants a well
-            filled out Conditions object, but doesn't need the sky since
-            that can be slower to load. Default False.
-        wind_data : None
-            If one wants to replace the default wind_data object. Should
-            be an object with a __call__ method that takes the time and
-            returns a tuple with the wind speed (m/s) and originating
-            direction (radians east of north)
-        starting_time_key : str
-            What key in the almanac to use to determine the start of
-            observing on a night. Default "sun_n12_setting", e.g., sun
-            at -12 degrees and setting. Other options are
-            "sun_n18_setting" and "sunset"
-        ending_time_key : str
-            What key in the almanac to use to signify it is time to skip
-            to the next night. Default "sun_n12_rising", e.g., sun at
-            -12 degrees and rising. Other options are "sun_n18_rising"
-            and "sunrise"
-        """
 
         if nside is None:
             nside = set_default_nside()
         self.nside = nside
 
-        self.wind_data = wind_data
+        # Set the time now - mjd
+        # and the time of the survey start
+        if mjd_start is None:
+            mjd_start = survey_start_mjd()
+        self.mjd_start = mjd_start
+
+        if mjd is None:
+            mjd = mjd_start
+
+        self.filterlist = ["u", "g", "r", "i", "z", "y"]
 
         self.cloud_limit = cloud_limit
         self.no_sky = no_sky
-
         self.alt_min = np.radians(alt_min)
         self.lax_dome = lax_dome
-        self.mjd_start = survey_start_mjd() if mjd_start is None else mjd_start
         self.starting_time_key = starting_time_key
         self.ending_time_key = ending_time_key
 
@@ -153,16 +183,23 @@ class ModelObservatory:
             lat=self.site.latitude, lon=self.site.longitude, height=self.site.height
         )
 
-        # Load up all the models we need
+        # Set up the almanac - use mjd_start to keep "night" count the same.
+        self.almanac = Almanac(mjd_start=self.mjd_start)
 
+        # Load up all the models we need
+        # Use mjd_start to ensure models always initialize to the same
+        # starting point in time.
         mjd_start_time = Time(self.mjd_start, format="mjd")
-        # Downtime
+
+        # Set up the downtime
         if isinstance(downtimes, str):
             if downtimes == "ideal":
                 self.downtimes = np.array(
                     list(zip([], [])),
                     dtype=list(zip(["start", "end"], [float, float])),
                 )
+            else:
+                warnings.warn("Downtimes should be a string equal to " "'ideal', an array or None")
         elif downtimes is None:
             self.down_nights = []
             self.sched_downtime_data = ScheduledDowntimeData(mjd_start_time)
@@ -189,7 +226,7 @@ class ModelObservatory:
             # Make sure there aren't any overlapping downtimes
             diff = self.downtimes["start"][1:] - self.downtimes["end"][0:-1]
             while np.min(diff) < 0:
-                # Should be able to do this wihtout a loop, but this works
+                # Should be able to do this without a loop, but this works
                 for i, dt in enumerate(self.downtimes[0:-1]):
                     if self.downtimes["start"][i + 1] < dt["end"]:
                         new_end = np.max([dt["end"], self.downtimes["end"][i + 1]])
@@ -202,8 +239,12 @@ class ModelObservatory:
         else:
             self.downtimes = downtimes
 
+        # Set the wind data
+        self.wind_data = wind_data
+
+        # Set up the seeing data
         if seeing_data == "ideal":
-            self.seeing_data = NominalSeeing()
+            self.seeing_data = ConstantSeeingData()
         elif seeing_data is not None:
             self.seeing_data = seeing_data
         else:
@@ -213,46 +254,49 @@ class ModelObservatory:
         for i, filtername in enumerate(self.seeing_model.filter_list):
             self.seeing_indx_dict[filtername] = i
 
+        self.seeing_fwhm_eff = {}
+        for key in self.filterlist:
+            self.seeing_fwhm_eff[key] = np.zeros(hp.nside2npix(self.nside), dtype=float)
+
+        # Set up the cloud data
         if cloud_data == "ideal":
-            self.cloud_data = NoClouds()
+            self.cloud_data = ConstantCloudData()
         elif cloud_data is not None:
             self.cloud_data = cloud_data
         else:
             self.cloud_data = CloudData(mjd_start_time, cloud_db=cloud_db, offset_year=cloud_offset_year)
 
+        # Set up the skybrightness
         if not self.no_sky:
             self.sky_model = sb.SkyModelPre(init_load_length=init_load_length)
         else:
             self.sky_model = None
 
+        # Set up the kinematic model
         if kinem_model is None:
             self.observatory = KinemModel(mjd0=self.mjd_start)
         else:
             self.observatory = kinem_model
 
-        self.filterlist = ["u", "g", "r", "i", "z", "y"]
-        self.seeing_fwhm_eff = {}
-        for key in self.filterlist:
-            self.seeing_fwhm_eff[key] = np.zeros(hp.nside2npix(self.nside), dtype=float)
-
-        self.almanac = Almanac(mjd_start=self.mjd_start)
-
         # Let's make sure we're at an openable MJD
         good_mjd = False
-        to_set_mjd = self.mjd_start
+        to_set_mjd = mjd
         while not good_mjd:
             good_mjd, to_set_mjd = self.check_mjd(to_set_mjd)
         self.mjd = to_set_mjd
 
-        sun_moon_info = self.almanac.get_sun_moon_positions(self.mjd)
-        season_offset = create_season_offset(self.nside, sun_moon_info["sun_RA"])
+        sun_moon_info = self.almanac.get_sun_moon_positions(mjd)
+        # Create the map of the season offsets - this map is constant
+        ra, dec = _hpid2_ra_dec(nside, np.arange(hp.nside2npix(self.nside)))
+        ra_deg = np.degrees(ra)
+        self.season_map = calc_season(ra_deg, [self.mjd_start], self.mjd_start).flatten()
         self.sun_ra_start = sun_moon_info["sun_RA"] + 0
-        self.season_offset = season_offset
         # Conditions object to update and return on request
+        # (at present, this is not updated -- recreated, below).
         self.conditions = Conditions(
             nside=self.nside,
             mjd_start=self.mjd_start,
-            season_offset=self.season_offset,
+            season_map=self.season_map,
             sun_ra_start=self.sun_ra_start,
         )
 

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -282,7 +282,7 @@ class ModelObservatory:
         self.conditions = Conditions(
             nside=self.nside,
             mjd_start=self.mjd_start,
-            season_offset=self.season_offset,
+            season_map=self.season_map,
             sun_ra_start=self.sun_ra_start,
             mjd=self.mjd,
         )

--- a/rubin_scheduler/scheduler/surveys/ddf_presched.py
+++ b/rubin_scheduler/scheduler/surveys/ddf_presched.py
@@ -7,109 +7,98 @@ import numpy as np
 
 from rubin_scheduler.data import get_data_dir
 from rubin_scheduler.scheduler.utils import scheduled_observation
+from rubin_scheduler.site_models import Almanac
 from rubin_scheduler.utils import calc_season, ddf_locations, survey_start_mjd
 
 
-def ddf_slopes(ddf_name, raw_obs, night_season):
+def ddf_slopes(ddf_name, raw_obs, night_season, season_seq=30, min_season_length=0 / 365.25):
     """
     Let's make custom slopes for each DDF
 
     Parameters
     ----------
-    ddf_name : str
+    ddf_name : `str`
        The DDF name to use
-    raw_obs : np.array
+    raw_obs : `np.array`, (N,)
         An array with values of 1 or zero. One element per night, value of
         1 indicates the night is during an active observing season.
-    night_season : np.array
-        An array of floats with the fractional season value
-        (e.g., 0.5 would be half way through the first season)
+    night_season : `np.array`, (N,)
+        An array of floats with the fractional season value.
+        Season values range from 0-1 for the first season;
+        0.5 would be the "peak" of seasonal visibility.
+        These should ONLY be the night the field should be 'active'
+        (take out the season ends first).
+    season_seq : `int`, optional
+        Number of sequences to try to place into each season.
+        Default of 30.
+    min_season_length : `float`, optional
+        The minimum season length to allow before discarding the
+        season. Default of 0 currently doesn't discard any seasons,
+        on the basis that most of the short season concerns will be
+        early in the survey and we'd rather have some observations early
+        than wait.
     """
 
     # OK, so 258 sequences is ~1% of the survey
     # so a 25.8 sequences is a 0.1% season
     # COSMOS is going to be 0.7% for 3 years, then 0.175 for the rest.
 
-    ss = 30  # standard season, was 45
+    int_season = np.floor(night_season)
 
-    if (ddf_name == "ELAISS1") | (ddf_name == "XMM_LSS") | (ddf_name == "ECDFS"):
-        # Dict with keys for each season and values of the number of
-        # sequences to attempt.
-        season_vals = {
-            0: 10,
-            1: ss,
-            2: ss,
-            3: ss,
-            4: ss,
-            5: ss,
-            6: ss,
-            7: ss,
-            8: ss,
-            9: ss,
-            10: 10,
-        }
+    n_season = night_season[np.where(raw_obs)]
+    r_season = int_season[np.where(raw_obs)]
+    season_list = np.unique(r_season)
 
-        round_season = np.floor(night_season)
+    # Calculate season length for each season
+    # In general this should be the same each season except for first and last
+    season_length = np.zeros(len(season_list), float)
+    for i, season in enumerate(season_list):
+        match = np.where(r_season == season)
+        season_length[i] = n_season[match].max() - n_season[match].min()
 
-        cumulative_desired = np.zeros(raw_obs.size, dtype=float)
-        for season in np.unique(round_season):
-            in_season = np.where(round_season == season)
-            cumulative = np.cumsum(raw_obs[in_season])
-            if cumulative.max() > 0:
-                cumulative = cumulative / cumulative.max() * season_vals[season]
-                cumulative_desired[in_season] = cumulative + np.max(cumulative_desired)
+    # Determine goal number of sequences in each season.
+    season_vals = np.ones(len(season_list), float) * season_seq
+    # Adjust other seasons, relative to the max season length.
+    season_vals = season_vals * season_length / np.max(season_length)
+    # EXCEPT - throw out seasons which are too short
+    too_short = np.where(season_length < min_season_length)
+    season_vals[too_short] = 0
 
-    if ddf_name == "EDFS_a":
-        season_vals = {
-            0: 10,
-            1: ss,
-            2: ss,
-            3: ss,
-            4: ss,
-            5: ss,
-            6: ss,
-            7: ss,
-            8: ss,
-            9: ss,
-            10: 10,
-        }
-
-        round_season = np.floor(night_season)
-
-        cumulative_desired = np.zeros(raw_obs.size, dtype=float)
-        for season in np.unique(round_season):
-            in_season = np.where(round_season == season)
-            cumulative = np.cumsum(raw_obs[in_season])
-            if cumulative.max() > 0:
-                cumulative = cumulative / cumulative.max() * season_vals[season]
-                cumulative_desired[in_season] = cumulative + np.max(cumulative_desired)
-
+    # Add extra adjustment for COSMOS to boost visits in seasons 0-3
+    # Also boost -1 season, if it's not too short
+    boost_early_years = 5
     if ddf_name == "COSMOS":
-        # looks like COSMOS has no in-season time for 10 at the
-        # current start mjd.
-        season_vals = {
-            0: 10,
-            1: ss * 5,
-            2: ss * 5,
-            3: ss * 2,
-            4: ss,
-            5: ss,
-            6: ss,
-            7: ss,
-            8: ss,
-            9: ss,
-            10: 10,
-        }
+        early_season = np.where(season_list == -1)[0]
+        if len(early_season) > 0:
+            max_n_seq_early = (season_length[early_season][0] * 365.25) / 3
+            # Choose the minimum of - sequence every third night (?)
+            # or the standard season sequence * boost_early_years.
+            season_vals[early_season] = np.min([max_n_seq_early, season_seq * boost_early_years])
+        first_full_two_seasons = np.where((season_list == 0) | (season_list == 1))
+        season_vals[first_full_two_seasons] *= boost_early_years
+        third_season = np.where(season_list == 2)
+        season_vals[third_season] *= boost_early_years / 2.5
 
-        round_season = np.floor(night_season)
+    if ddf_name == "EDFS_b":
+        # EDFS_b ddf visits are allocated some other way
+        season_vals = season_vals * 0
 
-        cumulative_desired = np.zeros(raw_obs.size, dtype=float)
-        for season in np.unique(round_season):
-            in_season = np.where(round_season == season)[0]
-            cumulative = np.cumsum(raw_obs[in_season])
-            if cumulative.max() > 0:
-                cumulative = cumulative / cumulative.max() * season_vals[season]
-                cumulative_desired[in_season] = cumulative + np.max(cumulative_desired)
+    # Round the season_vals -- we're looking for integer numbers of sequences
+    season_vals = np.round(season_vals)
+
+    # assign cumulative values
+    cumulative_desired = np.zeros(raw_obs.size, dtype=float)
+    for i, season in enumerate(season_list):
+        this_season = np.where(int_season == season)
+        # raw_obs gives a way to scale the season_vals across the nights
+        # in the season -- raw_obs = 1 for peak of season, 0 when
+        # beyond the season_unobs_frac, and a fraction for low_season_frac
+        cumulative = np.cumsum(raw_obs[this_season])
+        if cumulative.max() > 0:
+            cumulative = cumulative / cumulative.max() * season_vals[i]
+            cumulative_desired[this_season] = cumulative + np.max(cumulative_desired)
+
+    # print(ddf_name, season_vals, cumulative_desired.max())
 
     return cumulative_desired
 
@@ -180,87 +169,145 @@ def optimize_ddf_times(
     airmass_limit=2.5,
     sky_limit=None,
     g_depth_limit=23.5,
-    season_unobs_frac=0.1,
+    season_unobs_frac=0.2,
+    low_season_frac=0,
+    low_season_rate=0.3,
+    mjd_start=None,
 ):
     """
 
     Parameters
     ----------
-    ddf : `str`
-        The name of the DDF
+    ddf_name : `str`
+        The name of the DDF, used to identify visits scheduled for each DDF.
+    ddf_RA : `float`
+        The RA of the DDF, used to calculate the season values. In degrees.
     ddf_grid : `np.array`
         An array with info for the DDFs. Generated by the
         rubin_scheduler.scheduler/surveys/generate_ddf_grid.py` script
-    season_unobs_frac : `float`
-        7.2 month observing season if season_unobs_frac = 0.2
-        (shaves 20% off each end of the full year)
-    sequence_time : `float`
-        How long a sequence is expected to be (minutes). Used to make
-        sure things are not scheduled too close to twilight.
+        The time spacing in this is approximately 15 or 30 minutes,
+        and includes visits which may be during twilight.
+    sun_limit : `float`, optional
+        The maximum sun altitude allowed when prescheduling DDF visits.
+        In degrees.
+    sequence_time : `float`, optional
+        Expected time for each DDF sequence, used to avoid hitting the
+        sun_limit (running DDF visits into twilight). In minutes.
+    airmass_limit : `float`, optional
+        The maximum airmass allowed when prescheduling DDF visits.
+    sky_limit : `float`, optional
+        The maximum skybrightness allowed when prescheduling DDF visits.
+        This is a skybrightness limit in g band (mags).
+        Default None imposes no limit.
+    g_depth_limit : `float`, optional
+        The minimum g band five sigma depth limit allowed when prescheduling
+        DDF visits. This is a depth limit in g band (mags).
+        The depth is calculated using skybrightness from skybrightness_pre,
+        a nominal FWHM_500 seeing at zenith of 0.7" (resulting in airmass
+        dependent seeing) and exposure time.
+        Default 23.5. Set to None for no limit.
+    season_unobs_frac : `float`, optional
+        Defines the end of the range of the prescheduled observing season.
+        season runs from 0 (sun's apparent position is at the RA of the DDF)
+        to 1 (sun returns to an apparent position in the RA of the DDF).
+        The scheduled season runs from:
+        season_unobs_frac < season < (1-season_unobs_fract)
+    low_season_frac : `float`, optional
+        Defines the end of the range of the "low cadence" prescheduled
+        observing season.
+        The "standard cadence" season runs from:
+        low_season_frac < season < (1 - low_season_frac)
+        For an 'accordian' style DDF with fewer observations near
+        the ends of the season, set this to a value larger than
+        `season_unobs_frac`. Values smaller than `season_unobs_frac`
+        will result in DDFs with a constant rate throughout the season.
+    low_season_rate : `float`, optional
+        Defines the rate to use within the low cadence portion
+        of the season. During the standard season, the 'rate' is 1.
+        This is used in `ddf_slopes` to define the desired number of
+        cumulative observations for each DDF over time.
+    mjd_start : `float`, optional
+        The MJD of the start of the survey. Used to identify the
+        starting point when counting seasons.
+        Default None uses `survey_start_mjd()`.
     """
+    # Convert sun_limit and sequence_time to values expected internally.
     sun_limit = np.radians(sun_limit)
     sequence_time = sequence_time / 60.0 / 24.0  # to days
 
-    # XXX-- double check that I got this right
-    ack = ddf_grid["sun_alt"][0:-1] * ddf_grid["sun_alt"][1:]
-    night = np.zeros(ddf_grid.size, dtype=int)
-    night[np.where((ddf_grid["sun_alt"][1:] >= 0) & (ack < 0))] += 1
-    night = np.cumsum(night)
+    # Calculate the night value for each grid point.
+    almanac = Almanac(mjd_start=ddf_grid["mjd"].min())
+    almanac_indx = almanac.mjd_indx(ddf_grid["mjd"])
+    night = almanac.sunsets["night"][almanac_indx]
+
     ngrid = ddf_grid["mjd"].size
 
-    # set a sun, airmass, sky masks
+    # Set the sun mask.
     sun_mask = np.ones(ngrid, dtype=int)
     sun_mask[np.where(ddf_grid["sun_alt"] >= sun_limit)] = 0
-
     # expand sun mask backwards by the sequence time.
     n_back = np.ceil(sequence_time / (ddf_grid["mjd"][1] - ddf_grid["mjd"][0])).astype(int)
     shadow_indx = np.where(sun_mask == 0)[0] - n_back
     shadow_indx = shadow_indx[np.where(shadow_indx >= 0)]
-
     sun_mask[shadow_indx] = 0
 
+    # Set the airmass mask.
     airmass_mask = np.ones(ngrid, dtype=int)
     airmass_mask[np.where(ddf_grid["%s_airmass" % ddf_name] >= airmass_limit)] = 0
 
+    # Set the sky_limit mask, if provided.
     sky_mask = np.ones(ngrid, dtype=int)
     if sky_limit is not None:
         sky_mask[np.where(ddf_grid["%s_sky_g" % ddf_name] <= sky_limit)] = 0
         sky_mask[np.where(np.isnan(ddf_grid["%s_sky_g" % ddf_name]) == True)] = 0
 
+    # Set the m5 / g_depth_limit mask if provided.
     m5_mask = np.zeros(ngrid, dtype=bool)
     m5_mask[np.isfinite(ddf_grid["%s_m5_g" % ddf_name])] = 1
-
     if g_depth_limit is not None:
         m5_mask[np.where(ddf_grid["%s_m5_g" % ddf_name] < g_depth_limit)] = 0
 
+    # Combine the masks.
     big_mask = sun_mask * airmass_mask * sky_mask * m5_mask
 
+    # Identify which nights are useful to preschedule DDF visits.
     potential_nights = np.unique(night[np.where(big_mask > 0)])
-
     # prevent a repeat sequence in a night
     unights, indx = np.unique(night, return_index=True)
     night_mjd = ddf_grid["mjd"][indx]
-    # The season of each night
-    night_season = calc_season(ddf_RA, night_mjd)
 
-    raw_obs = np.ones(unights.size)
-    # take out the ones that are out of season
+    # Calculate season values for each night.
+    if mjd_start is None:
+        mjd_start = survey_start_mjd()
+    night_season = calc_season(ddf_RA, night_mjd, mjd_start)
+    # Mod by 1 to turn the season value in each night a simple 0-1 value
     season_mod = night_season % 1
-
+    # Remove the portions of the season beyond season_unobs_frac.
+    # Note that the "season" does include times where the field wouldn't
+    # really have been observable (depending on declination).
+    # Small values of season_unobs_frac may not influence the usable season.
     out_season = np.where((season_mod < season_unobs_frac) | (season_mod > (1.0 - season_unobs_frac)))
+    # Identify the low-season times.
+    low_season = np.where((season_mod < low_season_frac) | (season_mod > (1.0 - low_season_frac)))
+
+    # Turn these into the 'rate scale' per night that goes to `ddf_slopes`
+    raw_obs = np.ones(unights.size)
     raw_obs[out_season] = 0
+    raw_obs[low_season] = low_season_rate
 
     cumulative_desired = ddf_slopes(ddf_name, raw_obs, night_season)
 
+    # Identify which nights (only scheduling 1 sequence per night)
+    # would be usable, based on the masks above.
     night_mask = unights * 0
     night_mask[potential_nights] = 1
-
+    # Calculate expected cumulative sequence schedule.
     unight_sched = match_cumulative(cumulative_desired, mask=night_mask)
     cumulative_sched = np.cumsum(unight_sched)
 
     nights_to_use = unights[np.where(unight_sched == 1)]
 
-    # For each night, find the best time in the night.
+    # For each night, find the best time in the night and preschedule the DDF.
     # XXX--probably need to expand this part to resolve the times when
     # multiple things get scheduled
     mjds = []
@@ -287,13 +334,15 @@ def generate_ddf_scheduled_obs(
     sun_alt_max=-18,
     moon_min_distance=25.0,
     dist_tol=3.0,
-    season_unobs_frac=0.1,
     nvis_master=[8, 10, 20, 20, 24, 18],
     filters="ugrizy",
     nsnaps=[1, 2, 2, 2, 2, 2],
     mjd_start=None,
     survey_length=10.0,
     sequence_time=60.0,
+    season_unobs_frac=0.2,
+    low_season_frac=0,
+    low_season_rate=0.3,
 ):
     """
 
@@ -320,11 +369,6 @@ def generate_ddf_scheduled_obs(
     dist_tol : `float` (3)
         The distance tolerance for a visit to be considered matching a
         scheduled observation (degrees).
-    season_unobs_frac : `float` (0.1)
-        What fraction of the season should the DDF be considered
-        unobservable. Taken off both the  start and end of the year,
-        so a season frac of 0.1 means 20% of the time the DDF is
-        considered unobservable, so it will be in-season for 9.6 months.
     nvis_master : list of ints ([8, 10, 20, 20, 24, 18])
         The number of visits to make per filter
     filters : `str` (ugrizy)
@@ -336,6 +380,29 @@ def generate_ddf_scheduled_obs(
         rubin_sim.utils.survey_start_mjd
     survey_length : `float`
         Length of survey (years). Default 10.
+    sequence_time : `float`, optional
+        Expected time for each DDF sequence, used to avoid hitting the
+        sun_limit (running DDF visits into twilight). In minutes.
+    season_unobs_frac : `float`, optional
+        Defines the end of the range of the prescheduled observing season.
+        season runs from 0 (sun's apparent position is at the RA of the DDF)
+        to 1 (sun returns to an apparent position in the RA of the DDF).
+        The scheduled season runs from:
+        season_unobs_frac < season < (1-season_unobs_fract)
+    low_season_frac : `float`, optional
+        Defines the end of the range of the "low cadence" prescheduled
+        observing season.
+        The "standard cadence" season runs from:
+        low_season_frac < season < (1 - low_season_frac)
+        For an 'accordian' style DDF with fewer observations near
+        the ends of the season, set this to a value larger than
+        `season_unobs_frac`. Values smaller than `season_unobs_frac`
+        will result in DDFs with a constant rate throughout the season.
+    low_season_rate : `float`, optional
+        Defines the rate to use within the low cadence portion
+        of the season. During the standard season, the 'rate' is 1.
+        This is used in `ddf_slopes` to define the desired number of
+        cumulative observations for each DDF over time.
     """
     if data_file is None:
         data_file = os.path.join(get_data_dir(), "scheduler", "ddf_grid.npz")
@@ -376,6 +443,8 @@ def generate_ddf_scheduled_obs(
             ddf_grid,
             season_unobs_frac=season_unobs_frac,
             sequence_time=sequence_time,
+            low_season_frac=low_season_frac,
+            low_season_rate=low_season_rate,
         )[0]
         for mjd in mjds:
             for filtername, nvis, nexp in zip(filters, nvis_master, nsnaps):

--- a/rubin_scheduler/scheduler/utils/sky_area.py
+++ b/rubin_scheduler/scheduler/utils/sky_area.py
@@ -1,4 +1,5 @@
 __all__ = (
+    "get_current_footprint",
     "generate_all_sky",
     "filter_count_ratios",
     "SkyAreaGenerator",
@@ -22,6 +23,28 @@ from rubin_scheduler.utils import Site, _angular_separation, angular_separation
 
 from .footprints import ra_dec_hp_map
 from .utils import IntRounded, set_default_nside
+
+
+def get_current_footprint(nside):
+    """Convenience method to return the current footprint.
+
+    This is primarily a way to help rubin-sim users keep up to date
+    on footprint changes (as we have been moving to new subclasses).
+
+    Parameters
+    ----------
+    nside : `int`
+        The nside for the footprint map.
+
+    Returns
+    -------
+    footprint_arrays, label_array : `np.array`, (N,), `np.array`, (N,)
+        HEALPix target survey maps for ugrizy,
+        and array of string labels for each healpix to indicate the "region".
+    """
+    sky = EuclidOverlapFootprint(nside=nside)
+    footprints, labels = sky.return_maps()
+    return footprints, labels
 
 
 def generate_all_sky(nside=None, elevation_limit=20, mask=hp.UNSEEN):

--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -730,7 +730,7 @@ def scheduled_observation(n=1):
         The minimum distance to demand the moon should be away (radians)
     observed : `bool`
         If set to True, scheduler will probably consider this a
-        completed observation an never attempt it.
+        completed observation and never attempt it.
 
     """
 
@@ -808,22 +808,42 @@ def hp_kd_tree(nside=None, leafsize=100, scale=1e5):
 
 
 class HpInLsstFov:
-    """
-    Return the healpixels within a pointing.
-    A very simple LSST camera model with no chip/raft gaps.
+    """Return the healpixels in an underlying healpix grid that
+    overlap an observation/pointing.
+
+    This uses a very simple circular LSST camera model with no chip/raft gaps.
+
+    Parameters
+    ----------
+    nside : `int`, optional
+        Nside to match for the healpix array.
+        Default None uses `set_default_nside`.
+    fov_radius : `float`, optional
+        Radius of the field of view in degrees. Default 1.75
+        covers the inscribed circle.
+    scale : `float`, optional
+        How many sig figs to round when considering matches to healpixels.
+        Useful for ensuring identical results cross-ploatform where
+        float precision can vary.
+
+
+    Examples
+    --------
+    Set up the class, then call to convert pointings to indices in the
+    healpix array. Note that RA and dec should be in RADIANS.
+
+    ```
+    >>> ra = np.radians(30)
+    >>> dec = np.radians(-20)
+    >>> pointing2indx = HpInLsstFov()
+    >>> indices = pointing2indx(ra, dec)
+    >>> indices
+    [8138, 8267]
+    ```
+
     """
 
     def __init__(self, nside=None, fov_radius=1.75, scale=1e5):
-        """
-        Parameters
-        ----------
-        fov_radius : float (1.75)
-            Radius of the filed of view in degrees
-        scale : float (1e5)
-            How many sig figs to round off to. Useful for ensuring
-            identical results cross-ploatform where float precision
-            can vary.
-        """
         if nside is None:
             nside = set_default_nside()
 

--- a/rubin_scheduler/utils/season_utils.py
+++ b/rubin_scheduler/utils/season_utils.py
@@ -4,53 +4,108 @@ import numpy as np
 from astropy.coordinates import EarthLocation, get_sun
 from astropy.time import Time
 
+from .mjd_zero import survey_start_mjd
 
-def calc_season(ra, mjd):
-    """Calculate the 'season' in the survey for a series of ra/time
-    values of an observation. Based only on the RA of the point on the
-    sky, it calculates the 'season' based on when the sun passes through
-    this RA (this marks the start of a 'season').
 
-    Note that seasons should be calculated using the RA of a fixed point
-    on the sky, such as the slice_point['ra'] if calculating season
-    values for a series of opsim pointings on the sky. To convert to
-    integer seasons, use np.floor(seasons)
+def calc_season(ra, mjd, mjd_start=None, calc_diagonal=False):
+    """Calculate the season (of visibility) in the survey
+    for a series of ra/time values of an observation.
+
+    Based only on the RA of the point on the
+    sky, it calculates the 'season' based on when the sun
+    passes through this RA (this marks the start of a 'season').
+
 
     Parameters
     ----------
-    ra : `float`
-        The RA (in degrees) of the point on the sky
-    mjd : `np.ndarray`
+    ra : `float` or `np.ndarray` (N,)
+        The RA (in degrees) of the point(s) on the sky
+    mjd : `np.ndarray`, (M,)
         The times of the observations, in MJD days
+    mjd_start : `float`, optional
+        The time of the start of the survey.
+        Default None will use `rubin_scheduler.utils.survey_start_mjd()`.
+    calc_diagonal : `bool`, optional
+        If True AND if len(mjd) == len(ra), ONLY the 'diagonal'
+        elements of the seasons will be calculated.
+        That is: RA and mjd are assumed to be paired and the resulting
+        seasons will be a  1-d `np.array` of dimension (N,).
 
     Returns
     -------
-    seasons : `np.array`
-        The season values, as floats.
-    """
+    seasons : `np.array`, (M,) or `np.array` (N, M)
+        The season values, as either a 1-d or 2-d array, depending on
+        the value passed for ra and calc_diagonal.
 
-    if np.size(ra) > 1:
-        ValueError("The ra must be a single value, not array.")
+
+    Notes
+    -----
+    Seasons should be calculated using the RA of a fixed point
+    on the sky, such as the slice_point['ra'] if calculating season
+    values for a series of opsim pointings on the sky, rather
+    than the value for each visit.
+
+    To convert to integer seasons, use np.floor(seasons).
+
+    "Season 0" will be the first (full) season after the RA value becomes
+    visible for the first time after mjd_start.
+    This induces a "discontinuity" in the resulting season values,
+    corresponding to the RA where the survey started -- like the international
+    dateline (in this case, where season goes from
+    'past season' to 'new season').
+
+    The scheduler `season_calc` routine computes "season" independently,
+    and may have a 90 degree offset in the location of this 'skip'/zeropoint,
+    plus requires different calculation of `offset` values to account for
+    location on the sky.
+    """
+    # Just to make it simpler to get simple values back
+    try:
+        len(ra)
+        single_ra = False
+    except TypeError:
+        single_ra = True
+
+    if mjd_start is None:
+        mjd_start = survey_start_mjd()
 
     # A reference time and sun RA location to anchor the location of the Sun
     # This time was chosen as it is close to the expected start of the survey.
-    ref_time = 60575.0
-    ref_sun_ra = 179.20796047239727
-    # Calculate the fraction of the sphere/"year" for this location
-    offset = (ra - ref_sun_ra) / 360 * 365.25
-    # Calculate when the seasons should begin
-    season_began = ref_time + offset
-    # Calculate the season value for each point.
-    seasons = (mjd - season_began) / 365.25
+    # The time is an equinox point, so the sun is at dec=0.
+    ref_time = 60940.0
+    ref_sun_ra = 178.98403541421598
 
-    seasons = seasons - np.floor(np.min(seasons))
+    # Calculate the fraction of the sphere/"year" for these RAs on the sky.
+    offset = (ra - ref_sun_ra) / 360 * 365.25
+    # Turn the offsets into the (mjd) times that the season would start
+    # at each RA value, in the reference year.
+    season_began = ref_time + offset
+
+    # Add an adjustment so that the first season (season = 0)
+    # at each RA is in the year after mjd_start
+    first = np.floor((season_began - mjd_start) / 365.25)
+    season_began = season_began - first * 365.25
+
+    # Calculate the season value for each point.
+    # season_began is an N length array, matching "ra"
+    # mjds is an M length array, matching mjds (applied to every ra)
+    if single_ra:
+        seasons = (mjd - season_began) / 365.25
+    elif calc_diagonal and len(mjd) == len(ra):
+        seasons = (mjd - season_began) / 365.25
+    else:
+        seasons = np.zeros((len(ra), len(mjd)), dtype=float)
+        for i, r in enumerate(ra):
+            seasons[i] = (mjd - season_began[i]) / 365.25
+
     return seasons
 
 
 def _generate_reference():
     # The reference values for calc_season can be evaluated using
-    loc = EarthLocation.of_site("Rubin")
-    t = Time("2024-09-22T00:00:00.00", format="isot", scale="utc", location=loc)
+    loc = EarthLocation.of_site("Rubin", refresh_cache=True)
+    # time should ideally be near at equinox for RA projection considerations
+    t = Time("2025-09-22T00:00:00.00", format="isot", scale="utc", location=loc)
     print("Ref time", t.utc.mjd)
     print("Ref sun RA", get_sun(t).ra.deg, t.utc.mjd)
-    print("local sidereal time at season start", t.sidereal_time("apparent").deg)
+    print("local sidereal time at time", t.sidereal_time("apparent").deg)

--- a/tests/scheduler/test_features.py
+++ b/tests/scheduler/test_features.py
@@ -1,10 +1,13 @@
 import unittest
+from copy import deepcopy
 
 import numpy as np
 
 import rubin_scheduler.scheduler.features as features
 from rubin_scheduler.scheduler.model_observatory import ModelObservatory
-from rubin_scheduler.scheduler.utils import empty_observation
+from rubin_scheduler.scheduler.utils import HpInLsstFov, empty_observation
+from rubin_scheduler.skybrightness_pre import dark_sky
+from rubin_scheduler.utils import survey_start_mjd
 
 
 class TestFeatures(unittest.TestCase):
@@ -106,6 +109,182 @@ class TestFeatures(unittest.TestCase):
 
         note_last_observed.add_observation(observation=observation)
         assert note_last_observed.feature == observation["mjd"]
+
+    def test_NObservationsCurrentSeason(self):
+        # Start with basic NObservationsCurrentSeason - no restrictions
+        mjd_start = survey_start_mjd()
+        nside = 64
+        season_feature = features.NObservationsCurrentSeason(nside=nside, mjd_start=mjd_start)
+        # Check that season map changes as expected with updates in Conditions
+        conditions = features.Conditions(nside=nside)
+        conditions.mjd = mjd_start
+        season = deepcopy(season_feature.season)
+        # with same time, should have same seasons.
+        season_feature.season_update(conditions=conditions)
+        self.assertTrue(np.all(season_feature.season == season))
+        # Advancing time should update seasons in some parts of the sky
+        # And leave it the same in other parts of the sky
+        conditions.mjd = mjd_start + 100
+        season_feature.season_update(conditions=conditions)
+        self.assertTrue(np.any(season_feature.season != season))
+        self.assertTrue(np.any(season_feature.season == season))
+        season = deepcopy(season_feature.season)
+        # Do we send a warning if time goes backwards
+        # and keep the season and feature the same
+        conditions.mjd = mjd_start
+        with self.assertWarns(UserWarning):
+            season_feature.season_update(conditions=conditions)
+        self.assertTrue(np.all(season_feature.season == season))
+        # And do the same for observations - check update_seasons works
+        # Make some observations
+        observations = [empty_observation(), empty_observation()]
+        observations[0]["mjd"] = mjd_start
+        observations[0]["ID"] = 0
+        observations[1]["mjd"] = mjd_start + 100
+        observations[1]["ID"] = 1
+        season_feature = features.NObservationsCurrentSeason(nside=16, mjd_start=mjd_start)
+        season = deepcopy(season_feature.season)
+        season_feature.season_update(observation=observations[0])
+        self.assertTrue(np.all(season_feature.season == season))
+        season_feature.season_update(observation=observations[1])
+        self.assertTrue(np.any(season_feature.season != season))
+        self.assertTrue(np.any(season_feature.season == season))
+        season = deepcopy(season_feature.season)
+        # Make time go backwards .. should NOT warn but should not
+        # update feature.
+        # with self.assertWarns(UserWarning):
+        #    season_feature.season_update(observation=observations[0])
+        self.assertTrue(np.all(season_feature.season == season))
+
+        # Now check that the _feature) works as expected when we
+        # add_observation (i.e. we now care about location and healpix)
+        for obs in observations:
+            obs["RA"] = np.radians(30)
+            obs["dec"] = np.radians(-20)
+        observations[1]["mjd"] = mjd_start + 0.3
+        pointing2indx = HpInLsstFov(nside=nside)
+        indxs = pointing2indx(observations[0]["RA"], observations[0]["dec"])
+        # first with no restrictions
+        season_feature = features.NObservationsCurrentSeason(nside=nside, mjd_start=mjd_start)
+        self.assertTrue(np.all(season_feature.feature == 0))
+        season_feature.add_observation(observations[0], indxs)
+        # Assert that we added an observation at each of the indexes
+        self.assertTrue(np.all(season_feature.feature[indxs] == 1))
+        # and nowhere else
+        self.assertTrue(np.all(np.delete(season_feature.feature, indxs) == 0))
+        # Add another observation within a day
+        season_feature.add_observation(observations[1], indxs)
+        # Assert that we added an observation at each of the indexes
+        self.assertTrue(np.all(season_feature.feature[indxs] == 2))
+        # and nowhere else
+        self.assertTrue(np.all(np.delete(season_feature.feature, indxs) == 0))
+        # Add an observation at a different point on the sky, but where
+        # season should not turn oer for ra above yet.
+        observations.append(empty_observation())
+        observations[-1]["mjd"] = mjd_start + 10
+        observations[-1]["RA"] = np.radians(50)
+        observations[-1]["dec"] = np.radians(-20)
+        observations[-1]["ID"] = len(observations) - 1
+        indxs2 = pointing2indx(observations[-1]["RA"], observations[-1]["dec"])
+        season_feature.add_observation(observations[-1], indxs2)
+        self.assertTrue(np.all(season_feature.feature[indxs2] == 1))
+        self.assertTrue(np.all(season_feature.feature[indxs] == 2))
+        # Check that if we fast-forward to a future year, and add an
+        # observation that everything reset to 1 or 0.
+        observation = observations[0]
+        observation["mjd"] = mjd_start + 365.25 * 2
+        season_feature.add_observation(observation, indxs)
+        self.assertTrue(np.all(season_feature.feature[indxs] == 1))
+        self.assertTrue(np.all(np.delete(season_feature.feature, indxs) == 0))
+
+        # Set up to check add_observations_array - use observations from above.
+        observations[0]["mjd"] = mjd_start
+        observations_array = np.empty(len(observations), dtype=observations[0].dtype)
+        for i, obs in enumerate(observations):
+            observations_array[i] = obs
+        # Build observations_hpids_array.
+        # Find list of lists of healpixels
+        # (should match [indxs, indxs, indxs2] from above)
+        list_of_hpids = pointing2indx(observations_array["RA"], observations_array["dec"])
+        indxs_list = [indxs, indxs, indxs2]
+        for hi, ii in zip(list_of_hpids, indxs_list):
+            self.assertTrue(set(hi) == set(ii))
+        # Unravel list-of-lists (list_of_hpids) to match against observations
+        hpids = []
+        big_array_indx = []
+        for i, indxs in enumerate(list_of_hpids):
+            for indx in indxs:
+                hpids.append(indx)
+                big_array_indx.append(i)
+        hpids = np.array(hpids, dtype=[("hpid", int)])
+        # Set up format / dtype for observations_hpids_array
+        names = list(observations_array.dtype.names)
+        types = [observations_array[name].dtype for name in names]
+        names.append(hpids.dtype.names[0])
+        types.append(hpids["hpid"].dtype)
+        ndt = list(zip(names, types))
+        observations_hpids_array = np.empty(hpids.size, dtype=ndt)
+        # Populate observations_hpid_array - big_array_indx points
+        # between index in observations_array and index in hpid
+        observations_hpids_array[list(observations_array.dtype.names)] = observations_array[big_array_indx]
+        observations_hpids_array[hpids.dtype.names[0]] = hpids
+        # Now check that adding observations to feature via
+        # add_observations_array results in the same feature
+        feature_obs = features.NObservationsCurrentSeason(nside=nside, mjd_start=mjd_start)
+        for obs, idx in zip(observations, indxs_list):
+            feature_obs.add_observation(obs, idx)
+        feature_arr = features.NObservationsCurrentSeason(nside=nside, mjd_start=mjd_start)
+        feature_arr.add_observations_array(observations_array, observations_hpids_array)
+        self.assertTrue(np.all(feature_obs.season == feature_arr.season))
+        self.assertTrue(np.all(feature_obs.feature == feature_arr.feature))
+
+        # Check that feature works as expected when adding requirements.
+        # Add seeing requirement.
+        season_feature = features.NObservationsCurrentSeason(
+            nside=nside, mjd_start=mjd_start, seeing_fwhm_max=1.0
+        )
+        observation = empty_observation()
+        observation["mjd"] = mjd_start
+        observation["RA"] = np.radians(30)
+        observation["dec"] = np.radians(-20)
+        # Don't add if seeing is too bad
+        observation["FWHMeff"] = 1.5
+        pointing2indx = HpInLsstFov(nside=nside)
+        indxs = pointing2indx(observation["RA"], observation["dec"])
+        season_feature.add_observation(observation, indxs)
+        self.assertTrue(np.all(season_feature.feature == 0))
+        # Do add if seeing is good enough
+        observation["FWHMeff"] = 0.5
+        season_feature.add_observation(observation, indxs)
+        self.assertTrue(np.all(season_feature.feature[indxs] == 1))
+        # Add filter requirement.
+        season_feature = features.NObservationsCurrentSeason(
+            nside=nside, mjd_start=mjd_start, seeing_fwhm_max=1.0, filtername="r"
+        )
+        observation["filter"] = "g"
+        # Don't add if in the wrong filter
+        season_feature.add_observation(observation, indxs)
+        self.assertTrue(np.all(season_feature.feature == 0))
+        # Do add if correct filter and good seeing.
+        observation["filter"] = "r"
+        season_feature.add_observation(observation, indxs)
+        self.assertTrue(np.all(season_feature.feature[indxs] == 1))
+        # Add m5 requirement.
+        season_feature = features.NObservationsCurrentSeason(
+            nside=nside, mjd_start=mjd_start, seeing_fwhm_max=1.0, filtername="r", m5_penalty_max=0
+        )
+        dark_map = dark_sky(nside)["r"]
+        # Don't add if too bright
+        observation["fivesigmadepth"] = dark_map[indxs].min() - 10
+        season_feature.add_observation(observation, indxs)
+        self.assertTrue(np.all(season_feature.feature == 0))
+        # Do add if faint enough
+        observation["fivesigmadepth"] = dark_map[indxs].max() + 10
+        season_feature.add_observation(observation, indxs)
+        self.assertTrue(np.all(season_feature.feature[indxs] == 1))
+        # Should test also that add_observations_array works
+        # in these cases with added requirements .. but will leave it
+        # to the "restore" test in test_utils.py.
 
 
 if __name__ == "__main__":

--- a/tests/scheduler/test_features.py
+++ b/tests/scheduler/test_features.py
@@ -36,7 +36,7 @@ class TestFeatures(unittest.TestCase):
         self.assertEqual(np.max(pin.feature), 2.0)
 
     def test_conditions(self):
-        observatory = ModelObservatory()
+        observatory = ModelObservatory(init_load_length=1, mjd_start=survey_start_mjd())
         conditions = observatory.return_conditions()
         self.assertIsInstance(repr(conditions), str)
         self.assertIsInstance(str(conditions), str)
@@ -52,9 +52,6 @@ class TestFeatures(unittest.TestCase):
             new_lmst,
             (initial_lmst + step_days * sidereal_hours_per_day) % 24,
         )
-
-        # Test that the string representation works
-        _ = conditions.__str__()
 
         # Check that naked conditions work
         conditions_naked = features.Conditions()


### PR DESCRIPTION
While almost all of the time calc_season would be called with only a single RA, if it's confusing, we can make it multi-RA like this.

More importantly though, it does update the "zero point" for the seasons, to introduce the discontinuity in season count that exists in the scheduler code ..  This PR makes calc_season start counting at 1, and counting 'season' as starting when the RA value matches the RA of the Sun.  

I think this still offsets the zero point for the seasons by about 90 degrees from what the scheduler counts as the "start" of the season though.  I'm not sure if this is going to remain confusing or not.

```
import numpy as np
import matplotlib.pyplot as plt
from rubin_scheduler.utils import survey_start_mjd, calc_season

ra = np.arange(0, 360, 1)
mjds = np.arange(survey_start_mjd(), survey_start_mjd()+11*365.25, 1)
seasons = calc_season(ra, mjds)
seasons = np.swapaxes(seasons, 0, 1)
seasons = np.floor(seasons)

plt.imshow(seasons, aspect=.1, origin='lower')
plt.colorbar()
plt.xlabel("RA (deg)")
plt.ylabel("MJD")
```

<img width="614" alt="Screenshot 2024-03-08 at 7 51 01 PM" src="https://github.com/lsst/rubin_scheduler/assets/1855711/464475c2-91b0-4f6e-bc7d-cfab6913c298">
