### PR TITLE
Include a moon distance limit for scheduled observations.

### DIFF
--- a/rubin_scheduler/scheduler/surveys/ddf_presched.py
+++ b/rubin_scheduler/scheduler/surveys/ddf_presched.py
@@ -285,6 +285,7 @@ def generate_ddf_scheduled_obs(
     HA_min=21.0,
     HA_max=3.0,
     sun_alt_max=-18,
+    moon_min_distance=25.0,
     dist_tol=3.0,
     season_unobs_frac=0.1,
     nvis_master=[8, 10, 20, 20, 24, 18],
@@ -314,6 +315,8 @@ def generate_ddf_scheduled_obs(
         happen (degrees).
     HA_min/max : `float` (21, 3)
         The hour angle limits to permit observations to happen (hours).
+    moon_min_distance : `float`
+        The minimum distance to demand from the moon (degrees).
     dist_tol : `float` (3)
         The distance tolerance for a visit to be considered matching a
         scheduled observation (degrees).
@@ -347,6 +350,7 @@ def generate_ddf_scheduled_obs(
     alt_max = np.radians(alt_max)
     dist_tol = np.radians(dist_tol)
     sun_alt_max = np.radians(sun_alt_max)
+    moon_min_distance = np.radians(moon_min_distance)
 
     ddfs = ddf_locations()
     ddf_data = np.load(data_file)
@@ -416,6 +420,7 @@ def generate_ddf_scheduled_obs(
                     obs["alt_min"] = alt_min
                     obs["alt_max"] = alt_max
                     obs["sun_alt_max"] = sun_alt_max
+                    obs["moon_min_distance"] = moon_min_distance
                     all_scheduled_obs.append(obs)
 
                 else:
@@ -438,6 +443,7 @@ def generate_ddf_scheduled_obs(
                     obs["alt_min"] = alt_min
                     obs["alt_max"] = alt_max
                     obs["sun_alt_max"] = sun_alt_max
+                    obs["moon_min_distance"] = moon_min_distance
                     all_scheduled_obs.append(obs)
 
     result = np.concatenate(all_scheduled_obs)

--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -724,8 +724,10 @@ def scheduled_observation(n=1):
         running from 0 to 24 hours, the target RA,Dec must be greather
         than HA_max and less than HA_min. Set HA_min to 24 for
         no limit. (hours)
-    sun_alt_max : float
+    sun_alt_max : `float`
         The sun must be below sun_alt_max to execute. (radians)
+    moon_min_distance : `float`
+        The minimum distance to demand the moon should be away (radians)
     observed : `bool`
         If set to True, scheduler will probably consider this a
         completed observation an never attempt it.
@@ -773,10 +775,11 @@ def scheduled_observation(n=1):
         "HA_max",
         "HA_min",
         "sun_alt_max",
+        "moon_min_distance",
         "observed",
         "scripted_id",
     ]
-    types += [float, float, float, float, float, float, float, bool, int]
+    types += [float, float, float, float, float, float, float, float, bool, int]
     result = np.zeros(n, dtype=list(zip(names, types)))
     return result
 


### PR DESCRIPTION
Include a moon distance limit for scheduled observations. Prevents observations that are delayed a few days from having the moon sneak up on them. 