### PR TITLE
ENH add uniform/optimized rolling and tests for it

### DIFF
--- a/rubin_scheduler/scheduler/utils/footprints.py
+++ b/rubin_scheduler/scheduler/utils/footprints.py
@@ -77,10 +77,11 @@ def make_rolling_footprints(
     n_constant_end : `int`
         The number of constant seasons to end the survey with. Defaults to 6.
     uniform : `bool`
-        If True, the rolling sequence is adjusted in half of the sky to generate
-        uniform surveys during years between rolling cycles. For nslice=2 and
-        three cycles, years 1, 4, 7, and 10 will be uniform. For nslice=3 and
-        two cycles, years 1, 5, 9, and 10 will be uniform. Default is True.
+        If True, the rolling sequence is adjusted in half of the sky to
+        generate uniform surveys during years between rolling cycles. For
+        nslice=2 and three cycles, years 1, 4, 7, and 10 will be uniform.
+        For nslice=3 and two cycles, years 1, 5, 9, and 10 will be uniform.
+        Default is True.
 
     Returns
     -------

--- a/rubin_scheduler/scheduler/utils/footprints.py
+++ b/rubin_scheduler/scheduler/utils/footprints.py
@@ -114,15 +114,11 @@ def make_rolling_footprints(
     if uniform:
         for i in range(nslice):
             _roll = np.roll(rolling, i).tolist() + [1]
-            all_slopes.append(
-                start + _roll * n_cycles + end
-            )
+            all_slopes.append(start + _roll * n_cycles + end)
         for i in range(nslice):
             _roll = np.roll(rolling, i).tolist() + [1]
             _roll = [_roll[-1]] + _roll[1:-1] + [_roll[0]]
-            all_slopes.append(
-                start + _roll * n_cycles + end
-            )
+            all_slopes.append(start + _roll * n_cycles + end)
     else:
         rolling = rolling * n_cycles
         all_slopes = [start + np.roll(rolling, i).tolist() + end for i in range(nslice)]
@@ -144,12 +140,16 @@ def make_rolling_footprints(
 
     if uniform:
         split_wfd_indices = slice_quad_galactic_cut(
-            hp_footprints, nslice=nslice, wfd_indx=wfd_indx,
-            ra_range=(sun_ra_start + 1.5 * np.pi, sun_ra_start + np.pi/2),
+            hp_footprints,
+            nslice=nslice,
+            wfd_indx=wfd_indx,
+            ra_range=(sun_ra_start + 1.5 * np.pi, sun_ra_start + np.pi / 2),
         )
 
         split_wfd_indices_delayed = slice_quad_galactic_cut(
-            hp_footprints, nslice=nslice, wfd_indx=wfd_indx,
+            hp_footprints,
+            nslice=nslice,
+            wfd_indx=wfd_indx,
             ra_range=(sun_ra_start + np.pi / 2, sun_ra_start + 1.5 * np.pi),
         )
     else:
@@ -174,13 +174,13 @@ def make_rolling_footprints(
             rolling_footprints[i].set_footprint(key, temp)
 
         if uniform:
-            for _i in range(nslice, nslice*2):
+            for _i in range(nslice, nslice * 2):
                 # make a copy of the current filter
                 temp = hp_footprints[key] + 0
                 # Set the non-rolling area to zero
                 temp[non_wfd_indx] = 0
 
-                indx = split_wfd_indices_delayed[_i-nslice]
+                indx = split_wfd_indices_delayed[_i - nslice]
                 # invert the indices
                 ze = temp * 0
                 ze[indx] = 1
@@ -217,9 +217,7 @@ def _is_in_ra_range(ra, low, high):
         return (ra >= _low) | (ra <= _high)
 
 
-def slice_quad_galactic_cut(
-    target_map, nslice=2, wfd_indx=None, ra_range=None
-):
+def slice_quad_galactic_cut(target_map, nslice=2, wfd_indx=None, ra_range=None):
     """
     Helper function for generating rolling footprints
 

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -11,10 +11,10 @@ from rubin_scheduler.scheduler.model_observatory import KinemModel, ModelObserva
 from rubin_scheduler.scheduler.utils import (
     SchemaConverter,
     empty_observation,
+    make_rolling_footprints,
     restore_scheduler,
     run_info_table,
     season_calc,
-    make_rolling_footprints,
 )
 from rubin_scheduler.utils import survey_start_mjd
 
@@ -307,9 +307,8 @@ class TestUtils(unittest.TestCase):
         """Test that we can make a uniform folling footprint"""
 
         # utility function to get sun ra at a given mjd
+        from astropy.coordinates import EarthLocation, get_sun
         from astropy.time import Time
-        from astropy.coordinates import get_sun
-        from astropy.coordinates import EarthLocation
 
         def _get_sun_ra_at_mjd(mjd):
             t = Time(

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -313,7 +313,7 @@ class TestUtils(unittest.TestCase):
         def _get_sun_ra_at_mjd(mjd):
             t = Time(
                 mjd,
-                format='mjd',
+                format="mjd",
                 location=EarthLocation.of_site("Cerro Pachon"),
             )
             return get_sun(t).ra.deg

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -1,8 +1,8 @@
 import os
 import unittest
 
-import numpy as np
 import healpy as hp
+import numpy as np
 
 from rubin_scheduler.data import get_data_dir
 from rubin_scheduler.scheduler import sim_runner


### PR DESCRIPTION
This PR adds new uniform/optimized rolling functionality to the scheduler. It allows for special times during rolling surveys where the survey will come back to uniform. 

See PRs https://github.com/lsst-sims/sims_featureScheduler_runs3.4/pull/4 and https://github.com/lsst-sims/sims_featureScheduler_runs3.4/pull/3 for detailed tests.

This PR has the scheme in https://github.com/lsst-sims/sims_featureScheduler_runs3.4/pull/4.