### PR TITLE
typo in part of code that wasn't exercised

### DIFF
--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -562,7 +562,7 @@ class ModelObservatory:
         # If the observation has a rotTelPos set, use it to compute
         # rotSkyPos
         if np.isfinite(observation["rotTelPos"]):
-            observation["rotSkyPos"] = (obs_pa + observation["rotTelPos"]) % (2 * np.pi)
+            observation["rotSkyPos"] = (observation["rotTelPos"] - obs_pa) % (2 * np.pi)
             observation["rotTelPos"] = np.nan
         else:
             # Fall back to rotSkyPos_desired

--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -587,7 +587,7 @@ def empty_observation(n=1):
     Lots of additional fields that get filled in by the model observatory
     when the observation is completed.
     See documentation at:
-    https://rubin-scheduler.lsst.io/output_schema.html
+    https://rubin-scheduler.lsst.io/fbs-output-schema.html
 
     """
 


### PR DESCRIPTION
Typo fix in part of `ModelObservatory` that doesn't usually get called.