### PR TITLE
 tickets/PREOPS-5256: make rubin_scheduler.scheduler.utils.SchemaConverter.opsim2obs robust to columns of unexpected type

### DIFF
--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -506,12 +506,12 @@ class SchemaConverter:
         for key in self.angles_rad2deg:
             try:
                 df[key] = np.radians(df[key])
-            except KeyError:
+            except (KeyError, TypeError):
                 df[key] = np.nan
         for key in self.angles_hours2deg:
             try:
                 df[key] = df[key] * 24.0 / 360.0
-            except KeyError:
+            except (KeyError, TypeError):
                 df[key] = np.nan
 
         df = df.rename(index=str, columns=self.convert_dict)


### PR DESCRIPTION
The OR4 V4 opsim DB has a `psudoParaAngle` column of type `object` and value `None`, and `opsim2obs` throws an unhandled exception when it tries to convert this to degrees. Instead, catch the exception and set it to all `nan`.