### PR TITLE
Pin scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "matplotlib",
     "healpy",
     "numexpr",
-    "scipy",
+    "scipy<1.14",
     "astropy",
     "astroplan",
     "tables",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ matplotlib
 healpy
 pandas
 numexpr
-scipy
+scipy<1.14
 astropy
 astroplan
 pytables


### PR DESCRIPTION
Pin scipy for now, as 1.14 breaks healpy 1.16.6. 

There is a healpy 1.17 in a PR on the healpy repo, but the build problems look significant. 