### PR TITLE
OPSIM-1175: update the kinematic model and altazshadowmask basis function

### DIFF
--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -1393,8 +1393,13 @@ class SlewtimeBasisFunction(BaseBasisFunction):
     def _calc_value(self, conditions, indx=None):
         # If we are in a different filter, the
         # FilterChangeBasisFunction will take it
+        # But we can still use the MASK returned by
+        # the slewtime map to remove inaccessible parts of the sky
         if conditions.current_filter != self.filtername:
-            result = 0
+            if np.size(conditions.slewtime) > 1:
+                result = np.where(np.isfinite(conditions.slewtime), 0, np.nan)
+            else:
+                result = 0
         else:
             # Need to make sure smaller slewtime is larger reward.
             if np.size(conditions.slewtime) > 1:

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -1430,7 +1430,7 @@ class AggressiveSlewtimeBasisFunction(BaseBasisFunction):
         self.maxtime = max_time
         self.hard_max = hard_max
         self.order = order
-        self.result = np.zeros(hp.nside2npix(nside), dtype=float)
+        self.result = np.zeros(hp.nside2npix(self.nside), dtype=float)
         send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, indx=None):

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -45,6 +45,7 @@ __all__ = (
     "RewardNObsSequence",
     "FilterDistBasisFunction",
     "RewardRisingBasisFunction",
+    "send_unused_deprecation_warning",
 )
 
 import warnings

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -1,6 +1,5 @@
 __all__ = (
     "SolarElongMaskBasisFunction",
-    "ZenithMaskBasisFunction",
     "ZenithShadowMaskBasisFunction",
     "HaMaskBasisFunction",
     "MoonAvoidanceBasisFunction",
@@ -133,37 +132,6 @@ class SolarElongationMaskBasisFunction(BaseBasisFunction):
             & (IntRounded(conditions.solar_elongation) <= IntRounded(self.max_elong))
         )[0]
         result[in_range] = 1
-        return result
-
-
-class ZenithMaskBasisFunction(BaseBasisFunction):
-    """Just remove the area near zenith.
-
-    Superceded by the ZenithShadowMask basis function.
-
-    Parameters
-    ----------
-    min_alt : float (20.)
-        The minimum possible altitude (degrees)
-    max_alt : float (82.)
-        The maximum allowed altitude (degrees)
-    """
-
-    def __init__(self, min_alt=20.0, max_alt=82.0, nside=None):
-        super(ZenithMaskBasisFunction, self).__init__(nside=nside)
-        self.update_on_newobs = False
-        self.min_alt = np.radians(min_alt)
-        self.max_alt = np.radians(max_alt)
-        self.result = np.empty(hp.nside2npix(self.nside), dtype=float).fill(self.penalty)
-        send_unused_deprecation_warning()
-
-    def _calc_value(self, conditions, indx=None):
-        result = self.result.copy()
-        alt_limit = np.where(
-            (IntRounded(conditions.alt) > IntRounded(self.min_alt))
-            & (IntRounded(conditions.alt) < IntRounded(self.max_alt))
-        )[0]
-        result[alt_limit] = 1
         return result
 
 

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -259,8 +259,7 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         good = np.where((IntRounded(conditions.alt) >= min_alt) & (IntRounded(conditions.alt) <= max_alt))[0]
 
         in_range_alt[good] += 1
-        good = np.where((IntRounded(future_alt) >= min_alt) &
-                        (IntRounded(future_alt) <= max_alt))[0]
+        good = np.where((IntRounded(future_alt) >= min_alt) & (IntRounded(future_alt) <= max_alt))[0]
         in_range_alt[good] += 1
 
         # Check allowable azimuth range against azimuth values

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -306,7 +306,7 @@ class ZenithShadowMaskBasisFunction(BaseBasisFunction):
 
         self.min_alt = np.radians(min_alt)
         self.max_alt = np.radians(max_alt)
-        self.ra, self.dec = _hpid2_ra_dec(nside, np.arange(hp.nside2npix(nside)))
+        self.ra, self.dec = _hpid2_ra_dec(self.nside, np.arange(hp.nside2npix(self.nside)))
         self.shadow_minutes = np.radians(shadow_minutes / 60.0 * 360.0 / 24.0)
         # Compute the declination band where things could drift into zenith
         self.decband = np.zeros(self.dec.size, dtype=float)
@@ -486,7 +486,7 @@ class MaskAzimuthBasisFunction(BaseBasisFunction):
         self.az_max = IntRounded(np.radians(az_max))
         self.out_of_bounds_val = out_of_bounds_val
         self.result = np.ones(hp.nside2npix(self.nside))
-        send_unused_deprecation_warning()
+        send_unused_deprecation_warning(self.__class__.__name__)
 
     def _calc_value(self, conditions, indx=None):
         to_mask = np.where(

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -203,18 +203,23 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
     mask so if observations are taken in pairs, the second in the pair will
     not have moved into a masked region.
 
-    Masks any alt/az regions as specified by the conditions object, then
-    applies any additional altitude masking as suppied by the kwargs.
+    Masks any alt/az regions as specified by the conditions object, or
+    values as provided by the kwargs. If both are provided,
+    the most restrictive of each will be used.
     This mask is then extended using `shadow minutes`.
 
     Parameters
     ----------
-    nside : `int`
+    nside : `int` or None
         HEALpix nside. Default None will look up the package-wide default.
     min_alt : `float`
         Minimum altitude to apply to the mask. Default 20 (degrees).
     max_alt : `float`
         Maximum altitude to allow. Default 82 (degrees).
+    min_az : `float`
+        Minimum azimuth value to apply to the mask. Default 0 (degrees).
+    max_az : `float`
+        Maximum azimuth value to apply to the mask. Default 360 (degrees).
     shadow_minutes : `float`
         How long to extend masked area in longitude. Default 40 (minutes).
     """
@@ -224,11 +229,15 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         nside=None,
         min_alt=20.0,
         max_alt=82.0,
+        min_az=0,
+        max_az=360,
         shadow_minutes=40.0,
     ):
-        super(AltAzShadowMaskBasisFunction, self).__init__(nside=nside)
+        super().__init__(nside=nside)
         self.min_alt = np.radians(min_alt)
         self.max_alt = np.radians(max_alt)
+        self.min_az = np.radians(min_az)
+        self.max_az = np.radians(max_az)
         self.shadow_time = shadow_minutes / 60.0 / 24.0  # To days
 
     def _calc_value(self, conditions, indx=None):
@@ -244,41 +253,29 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         # very narrow or shadow time is very large.
         future_alt, future_az = conditions.future_alt_az(np.max(conditions.mjd + self.shadow_time))
 
-        # apply limits from the conditions object
-        for limits in conditions.tel_alt_limits:
-            good = np.where(
-                (IntRounded(conditions.alt) >= IntRounded(np.min(limits)))
-                & (IntRounded(conditions.alt) <= IntRounded(np.max(limits)))
-            )[0]
-            in_range_alt[good] += 1
-            good = np.where(
-                (IntRounded(future_alt) >= IntRounded(np.min(limits)))
-                & (IntRounded(future_alt) <= IntRounded(np.max(limits)))
-            )[0]
-            in_range_alt[good] += 1
+        # find minimum alt limits
+        min_alt = IntRounded(np.max([np.min(conditions.tel_alt_limits), self.min_alt]))
+        max_alt = IntRounded(np.min([np.max(conditions.tel_alt_limits), self.max_alt]))
+        min_az = IntRounded(np.max([np.min(conditions.tel_az_limits), self.min_az]))
+        max_az = IntRounded(np.min([np.max(conditions.tel_az_limits), self.max_az]))
 
-        for limits in conditions.tel_az_limits:
-            good = np.where(
-                (IntRounded(conditions.az) >= IntRounded(np.min(limits)))
-                & (IntRounded(conditions.az) <= IntRounded(np.max(limits)))
-            )[0]
-            in_range_az[good] += 1
-            good = np.where(
-                (IntRounded(future_az) >= IntRounded(np.min(limits)))
-                & (IntRounded(future_az) <= IntRounded(np.max(limits)))
-            )[0]
-            in_range_az[good] += 1
+        good = np.where((IntRounded(conditions.alt) >=  min_alt) &
+                        (IntRounded(conditions.alt) <= max_alt))[0]
+        in_range_alt[good] += 1
+        good = np.where((IntRounded(future_alt) >= min_alt) &
+                        (IntRounded(future_alt) <= max_alt))[0]
+        in_range_alt[good] += 1
+
+        good = np.where((IntRounded(conditions.az) >= min_az) &
+                        (IntRounded(conditions.az) <= max_az))[0]
+        in_range_az[good] += 1
+        good = np.where((IntRounded(future_az) >= min_az) &
+                        (IntRounded(future_az) <= max_az))[0]
+        in_range_az[good] += 1
 
         passed_all = np.where((in_range_alt > 1) & (in_range_az > 1))[0]
+        # Unmask the parts of the sky which are and will remain in alt/az range
         result[passed_all] = 0
-
-        # Apply additional alt constraint in case we want to be more
-        # conservative than the limit
-        result[np.where(IntRounded(conditions.alt) < IntRounded(self.min_alt))] = np.nan
-        result[np.where(IntRounded(conditions.alt) > IntRounded(self.max_alt))] = np.nan
-
-        result[np.where(IntRounded(future_alt) < IntRounded(self.min_alt))] = np.nan
-        result[np.where(IntRounded(future_alt) > IntRounded(self.max_alt))] = np.nan
 
         return result
 

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -209,7 +209,7 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         self,
         nside=None,
         min_alt=20.0,
-        max_alt=82.0,
+        max_alt=86.5,
         min_az=0,
         max_az=360,
         shadow_minutes=40.0,
@@ -242,11 +242,11 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         result[np.where(r_future_alt < self.r_min_alt)] = np.nan
         result[np.where(r_future_alt > self.r_max_alt)] = np.nan
         # Check the conditions objects altitude limits, now and future
-        if conditions.tel_alt_limits is not None:
+        if (conditions.tel_alt_limits is not None) and (len(conditions.tel_alt_limits) > 0):
             combined = np.zeros(hp.nside2npix(self.nside), dtype=float)
             for limits in conditions.tel_alt_limits:
                 # For conditions-based limits, must add pad
-                # And remember that discontiguous areas can be allowed
+                # And remember that discontinuous areas can be allowed
                 in_bounds = np.ones(hp.nside2npix(self.nside), dtype=float)
                 min_alt = IntRounded(limits[0] + conditions.altaz_limit_pad)
                 max_alt = IntRounded(limits[1] - conditions.altaz_limit_pad)
@@ -275,7 +275,7 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
             out_of_bounds = np.where((future_az - self.min_az) % (two_pi) > az_range)[0]
             result[out_of_bounds] = np.nan
         # Check the conditions objects azimuth limits, now and future
-        if conditions.tel_az_limits is not None:
+        if (conditions.tel_az_limits is not None) and (len(conditions.tel_az_limits) > 0):
             combined = np.zeros(hp.nside2npix(self.nside), dtype=float)
             for limits in conditions.tel_az_limits:
                 in_bounds = np.ones(hp.nside2npix(self.nside), dtype=float)

--- a/rubin_scheduler/scheduler/example/comcam_sv_scheduler_example.py
+++ b/rubin_scheduler/scheduler/example/comcam_sv_scheduler_example.py
@@ -30,7 +30,7 @@ from rubin_scheduler.scheduler.schedulers import ComCamFilterSched, CoreSchedule
 from rubin_scheduler.scheduler.surveys import BlobSurvey, FieldSurvey, GreedySurvey
 from rubin_scheduler.scheduler.utils import Footprint, get_current_footprint
 from rubin_scheduler.site_models import Almanac, ConstantSeeingData, ConstantWindData
-from rubin_scheduler.utils import ddf_locations, survey_start_mjd
+from rubin_scheduler.utils import survey_start_mjd
 
 
 def get_model_observatory(
@@ -229,8 +229,8 @@ def standard_masks(
             nside=nside,
             min_alt=min_alt,
             max_alt=max_alt,
-            # min_az=min_az,
-            # max_az=max_az,
+            min_az=min_az,
+            max_az=max_az,
             shadow_minutes=shadow_minutes,
         )
     )
@@ -818,29 +818,15 @@ def get_sv_fields() -> dict[str, dict[str, float]]:
         ("Rubin_SV_300_-41", 300.0, -41.0),  # High stellar densty, low extinction
         ("Rubin_SV_280_-48", 280.0, -48.0),  # High stellar densty, low extinction
         ("DEEP_B0", 310, -19),  # DEEP Solar System
-        ("ELAIS_S1", 9.45, -44.0),  # ELAIS-S1 LSST DDF
-        ("XMM_LSS", 35.708333, -4.75),  # LSST DDF
-        ("ECDFS", 53.125, -28.1),  # ECDFS
-        ("COSMOS", 150.1, 2.1819444444444445),  # COSMOS
-        ("EDFS_A", 58.9, -49.315),  # EDFS_a
+        ("ELAIS_S1", 9.45, -44.03),  # ELAIS-S1 LSST DDF
+        ("XMM_LSS", 35.575, -4.82),  # LSST DDF
+        ("ECDFS", 52.98, -28.1),  # ECDFS
+        ("COSMOS", 150.1, 2.23),  # COSMOS
+        ("EDFS_A", 58.9, -49.32),  # EDFS_a
         ("EDFS_B", 63.6, -47.6),  # EDFS_b
     )
 
     fields_dict = dict(zip([f[0] for f in fields], [{"RA": f[1], "Dec": f[2]} for f in fields]))
-
-    # Update ddf_locations to
-    survey_ddfs = ddf_locations()
-    ddf_radec = {}
-    for k in survey_ddfs:
-        kk = k.lower().replace("_", "").replace("-", "")
-        ddf_radec[kk] = survey_ddfs[k]
-    for field in fields_dict:
-        # see if the field names match any ddf field name, allowing for
-        # upper/lower case and -vs_ differences
-        ff = field.lower().replace("_", "").replace("-", "")
-        if ff in ddf_radec:
-            fields_dict[field]["RA"] = ddf_radec[ff][0]
-            fields_dict[field]["Dec"] = ddf_radec[ff][1]
 
     return fields_dict
 

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -77,168 +77,165 @@ class Conditions:
         """
         Attributes (Set on init)
         -----------
-        nside : int
+        nside : `int`
             Healpix resolution. All maps are set to this reslution.
         site : rubin_scheduler.Site object ('LSST')
             Contains static site-specific data (lat, lon, altitude, etc).
             Defaults to 'LSST'.
-        ra : np.array
+        ra : `np.ndarray`, (N,)
             A healpix array with the RA of each healpixel center (radians).
             Automatically generated.
-        dec : np.array
+        dec : `np.ndarray`, (N,)
             A healpix array with the Dec of each healpixel center (radians).
             Automatically generated.
 
         Attributes (to be set by user/telemetry stream/scheduler)
         -------------------------------------------
-        mjd : float
+        mjd : `float`
             Modified Julian Date (days).
-        bulk_cloud : float
+        bulk_cloud : `float`
             The fraction of sky covered by clouds. (In the future might
             update to transparency map)
-        cloud_map : np.array
+        cloud_map : `np.ndarray`, (N,)
             XXX--to be done. HEALpix array with cloudy pixels set to NaN.
-        slewtime : np.array
+        slewtime : `np.ndarray`, (N,)
             Healpix showing the slewtime to each healpixel center (seconds)
-        current_filter : str
+        current_filter : `str`
             The name of the current filter. (expect one of u, g, r, i, z, y).
-        mounted_filters : list of str
-            The filters that are currently mounted and thu available
-            (expect 5 of u, g, r, i, z, y)
-        night : int
+        mounted_filters : `list` [`str`]
+            The filters that are currently mounted and thus available
+            (expect 5 of u, g, r, i, z, y for LSSTCam).
+        night : `int`
             The current night number (days). Probably starts at 1.
-        skybrightness : dict of np.array
-            Dictionary keyed by filtername. Values are healpix arrays with
-            the sky brightness at each
+        skybrightness : `dict` {`str: `np.ndarray`, (N,)}
+            Dictionary keyed by filter name.
+            Values are healpix arrays with the sky brightness at each
             healpix center (mag/acsec^2)
-        fwhm_eff : dict of np.array
-            Dictionary keyed by filtername. Values are the effective seeing
-            FWHM at each healpix
+        fwhm_eff : `dict` {`str: `np.ndarray`, (N,)}
+            Dictionary keyed by filtername.
+            Values are the effective seeing FWHM at each healpix
             center (arcseconds)
-        moon_alt : float
+        moon_alt : `float`
             The altitude of the Moon (radians)
-        moon_az : float
+        moon_az : `float`
             The Azimuth of the moon (radians)
-        moon_ra : float
+        moon_ra : `float`
             RA of the moon (radians)
-        moon_dec : float
+        moon_dec : `float`
             Declination of the moon (radians)
-        moon_phase : float
+        moon_phase : `float`
             The Phase of the moon. (percent, 0=new moon, 100=full moon)
-        sun_alt : float
+        sun_alt : `float`
             The altitude of the sun (radians).
-        sun_az : float
+        sun_az : `float`
             The Azimuth of the sun (radians).
-        sun_ra : float
+        sun_ra : `float`
             The RA of the sun (radians).
-        sun_dec : float
+        sun_dec : `float`
             The Dec of the sun (radians).
-        tel_ra : float
+        tel_ra : `float`
             The current telescope RA pointing (radians).
-        tel_dec : float
+        tel_dec : `float`
             The current telescope Declination (radians).
-        tel_alt : float
+        tel_alt : `float`
             The current telescope altitude (radians).
-        tel_az : float
+        tel_az : `float`
             The current telescope azimuth (radians).
-        cumulative_azimuth_rad : float
-            The cummulative telescope azimuth (radians). For tracking
-            cable wrap
-        cloud_map : np.array
-            A healpix map with the cloud coverage. XXX-expand,
-            is this bool map? Transparency map?
-        airmass : np.array
+        cumulative_azimuth_rad : `float`
+            The cumulative telescope azimuth (radians).
+            Used for tracking cable wrap.
+        airmass : `np.ndarray`, (N,)
             A healpix map with the airmass value of each healpixel. (unitless)
-        wind_speed : float
+        wind_speed : `float`
             Wind speed (m/s).
-        wind_direction : float
+        wind_direction : `float`
             Direction from which the wind originates. A direction of
             0.0 degrees means the wind originates from the north and 90.0
             degrees from the east (radians).
-        sunset : float
+        sunset : `float`
             The MJD of sunset that starts the current night. Note MJDs of
             sunset, moonset, twilight times, etc are from interpolations.
             This means the sun may actually be slightly above/below the
             horizon at the given sunset time.
-        sun_n12_setting : float
-            The MJD of when the sun is at -12 degees altitude and
+        sun_n12_setting : `float`
+            The MJD of when the sun is at -12 degrees altitude and
             setting during the current night. From interpolation.
-        sun_n18_setting : float
+        sun_n18_setting : `float`
             The MJD when the sun is at -18 degrees altitude and setting
             during the current night. From interpolation.
-        sun_n18_rising : float
+        sun_n18_rising : `float`
             The MJD when the sun is at -18 degrees altitude and rising
             during the current night. From interpolation.
-        sun_n12_rising : float
+        sun_n12_rising : `float`
             The MJD when the sun is at -12 degrees altitude and rising
             during the current night. From interpolation.
-        sunrise : float
+        sunrise : `float`
             The MJD of sunrise during the current night. From interpolation
-        mjd_start : float
+        mjd_start : `float`
             The starting MJD of the survey.
-        moonrise : float
+        moonrise : `float`
             The MJD of moonrise during the current night. From interpolation.
-        moonset : float
-            The MJD of moonset during the current night. From interpolation.
-        moon_phase_sunset : float
-            The phase of the moon (0-100 illuminater) at sunset.
+        moonset : `float`
+            The MJD of moon set during the current night. From interpolation.
+        moon_phase_sunset : `float`
+            The phase of the moon (0-100 illuminated) at sunset.
             Useful for setting which filters should be loaded.
-        targets_of_opportunity : list of rubin_scheduler.scheduler.targetoO
+        targets_of_opportunity : `list` [`rubin_scheduler.scheduler.targetoO`]
             targetoO objects.
-        planet_positions : dict
+        planet_positions : `dict` {`str`: `float`}
             Dictionary of planet name and coordinate e.g., 'venus_RA',
             'mars_dec'
-        scheduled_observations : np.array
+        scheduled_observations : `np.ndarray`, (M,)
             A list of MJD times when there are scheduled observations.
             Defaults to empty array.
-        tel_az_limits : list of float pairs
-            A list of lists giving valid azimuth ranges. e.g.,
-            [0, 2*np.pi] would mean all azimuth values are valid, while
-            [[0, np.pi/2], [3*np.pi/2, 2*np.pi]] would mean anywhere in
-            the south is invalid.  Radians.
-        tel_alt_limits : list of float pairs
-            A list of lists giving valid altitude ranges. Radians.
+        tel_az_min : `float`
+        tel_az_max : `float
+        tel_alt_min : `float`
+        tel_alt_max : `float`
+            Valid altitude and azimuth ranges (radians).
+            Order matters for azimuth - 270 degrees to 90 degrees
+            is different than 90 degrees to 270 degrees.
 
         Attributes (calculated on demand and cached)
         ------------------------------------------
-        alt : np.array
-            Altitude of each healpixel (radians). Recaclulated if mjd is
+        alt : `np.ndarray`, (N,)
+            Altitude of each healpixel (radians). Recalculated if mjd is
             updated. Uses fast approximate equation for converting
             RA,Dec to alt,az.
-        az : np.array
-            Azimuth of each healpixel (radians). Recaclulated if mjd is
+        az : `np.ndarray`, (N,)
+            Azimuth of each healpixel (radians). Recalculated if mjd is
             updated. Uses fast approximate equation for converting RA,Dec
             to alt,az.
-        pa : np.array
-            The parallactic angle of each healpixel (radians). Recaclulated
+        pa : `np.ndarray`, (N,)
+            The parallactic angle of each healpixel (radians). Recalculated
             if mjd is updated. Based on the fast approximate alt,az values.
         season : `np.array`, (N,)
             The current season value (0-1) at each healpixel.
             Recalculated if mjd is updated. Used by features that would
             otherwise need to calculate `season`.
             Uses `rubin_scheduler.utils.calc_season`.
-        lmst : float
-            The local mean sidearal time (hours). Updates is mjd is changed.
-        m5_depth : dict of np.array
+        lmst : `float`
+            The local mean sidereal time (hours). Updates is mjd is changed.
+        m5_depth : `dict` {`str: `np.ndarray`, (N,)}
             the 5-sigma limiting depth healpix maps, keyed by filtername
             (mags). Will be recalculated if the skybrightness, seeing,
             or airmass are updated.
-        HA : np.array
+        HA : `np.ndarray`, (N,)
             Healpix map of the hour angle of each healpixel (radians).
             Runs from 0 to 2pi.
-        az_to_sun : np.array
+        az_to_sun : `np.ndarray`, (N,)
             Healpix map of the azimuthal distance to the sun for each
             healpixel (radians)
-        az_to_anitsun : np.array
+        az_to_anitsun : `np.ndarray`, (N,)
             Healpix map of the azimuthal distance to the anit-sun for each
             healpixel (radians)
-        solar_elongation : np.array
+        solar_elongation : `np.ndarray`, (N,)
             Healpix map of the solar elongation (angular distance to the sun)
             for each healpixel (radians)
 
         Attributes (set by the scheduler)
         -------------------------------
-        queue : list of observation objects
+        queue : `list` [`observation` objects]
             The current queue of observations core_scheduler is waiting to
             execute.
 
@@ -341,8 +338,10 @@ class Conditions:
         self.cumulative_azimuth_rad = None
 
         # Telescope limits
-        self.tel_az_limits = None
-        self.tel_alt_limits = None
+        self.tel_az_min = None
+        self.tel_az_max = None
+        self.tel_alt_min = None
+        self.tel_alt_max = None
 
         # Full sky cloud map
         self._cloud_map = None

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -188,13 +188,15 @@ class Conditions:
         scheduled_observations : `np.ndarray`, (M,)
             A list of MJD times when there are scheduled observations.
             Defaults to empty array.
-        tel_az_min : `float`
-        tel_az_max : `float
-        tel_alt_min : `float`
-        tel_alt_max : `float`
-            Valid altitude and azimuth ranges (radians).
-            Order matters for azimuth - 270 degrees to 90 degrees
-            is different than 90 degrees to 270 degrees.
+        tel_az_limits : `list` [[`float`, `float`]]
+            A list of lists giving valid azimuth ranges. e.g.,
+            [0, 2*np.pi] would mean all azimuth values are valid, while
+            [[0, np.pi/2], [3*np.pi/2, 2*np.pi]] would mean anywhere in
+            the south is invalid.  Radians.
+        tel_alt_limits : `list` [[`float`, `float`]]
+            A list of lists giving valid altitude ranges. Radians.
+        altaz_limit_pad : `float`
+            Pad to surround the tel_az_limits and tel_alt_limits with.
 
         Attributes (calculated on demand and cached)
         ------------------------------------------
@@ -338,10 +340,11 @@ class Conditions:
         self.cumulative_azimuth_rad = None
 
         # Telescope limits
-        self.tel_az_min = None
-        self.tel_az_max = None
-        self.tel_alt_min = None
-        self.tel_alt_max = None
+        self.tel_az_limits = None
+        self.tel_alt_limits = None
+        self.kinematic_alt_limits = None
+        self.kinematic_az_limits = None
+        self.altaz_limit_pad = None
 
         # Full sky cloud map
         self._cloud_map = None

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -344,6 +344,8 @@ class Conditions:
         self.tel_alt_limits = None
         self.kinematic_alt_limits = None
         self.kinematic_az_limits = None
+        # This has a (reasonable) default value, to avoid failure of
+        # AltAzShadowMask in case this isn't set otherwise.
         self.altaz_limit_pad = np.radians(2)
 
         # Full sky cloud map

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -339,11 +339,16 @@ class Conditions:
         self.tel_az = None
         self.cumulative_azimuth_rad = None
 
-        # Telescope limits
+        # Telescope limits - these can be None
+        # These should be in radians.
         self.tel_az_limits = None
         self.tel_alt_limits = None
-        self.kinematic_alt_limits = None
-        self.kinematic_az_limits = None
+        # Kinematic model (real slew) limits - these can't be None
+        # if you are using the AltAzShadowMaskBasisFunction.
+        # These generous limits won't restrict the AltAzShadowMask.
+        # Radians.
+        self.kinematic_alt_limits = [np.radians(-10), np.radians(100)]
+        self.kinematic_az_limits = [np.radians(-250), np.radians(250)]
         # This has a (reasonable) default value, to avoid failure of
         # AltAzShadowMask in case this isn't set otherwise.
         self.altaz_limit_pad = np.radians(2)

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -344,7 +344,7 @@ class Conditions:
         self.tel_alt_limits = None
         self.kinematic_alt_limits = None
         self.kinematic_az_limits = None
-        self.altaz_limit_pad = None
+        self.altaz_limit_pad = np.radians(2)
 
         # Full sky cloud map
         self._cloud_map = None

--- a/rubin_scheduler/scheduler/model_observatory/kinem_model.py
+++ b/rubin_scheduler/scheduler/model_observatory/kinem_model.py
@@ -5,9 +5,9 @@ import numpy as np
 from rubin_scheduler.scheduler.utils import smallest_signed_angle
 from rubin_scheduler.utils import (
     Site,
+    _approx_alt_az2_ra_dec,
     _approx_altaz2pa,
     _approx_ra_dec2_alt_az,
-    _approx_alt_az2_ra_dec,
     rotation_converter,
 )
 

--- a/rubin_scheduler/scheduler/model_observatory/kinem_model.py
+++ b/rubin_scheduler/scheduler/model_observatory/kinem_model.py
@@ -280,10 +280,10 @@ class KinemModel:
         azimuth_maxpos=250.0,
         altitude_maxspeed=3.5,
         altitude_accel=3.5,
-        altitude_jerk=20.0,
+        altitude_jerk=14.0,
         azimuth_maxspeed=7.0,
         azimuth_accel=7.0,
-        azimuth_jerk=40.0,
+        azimuth_jerk=28.0,
         settle_time=3.0,
     ):
         """Configure the telescope (TMA) movement and position.
@@ -570,7 +570,7 @@ class KinemModel:
             d1 = (az_rad - self.telaz_minpos_rad) % (two_pi)
             d2 = (starting_az_rad - self.telaz_minpos_rad) % (two_pi)
             delta_aztel = d2 - d1
-            delta_aztel[out_of_bounds] = np.nan
+            delta_aztel[out_of_bounds] = np.inf
             az_flag = "restricted"
 
         # Calculate how long the telescope will take to slew to this

--- a/rubin_scheduler/scheduler/model_observatory/kinem_model.py
+++ b/rubin_scheduler/scheduler/model_observatory/kinem_model.py
@@ -524,18 +524,18 @@ class KinemModel:
         # in altitude, azimuth, and camera rotator (if applicable).
         # Delta Altitude
         delta_alt = np.abs(alt_rad - starting_alt_rad)
-        # Delta Azimuth - there are two different 'directions'
+        # Delta Azimuth - there are two different directions
         # possible to travel for azimuth. First calculate the shortest.
         delta_az_short = smallest_signed_angle(starting_az_rad, az_rad)
-        # And then calculate the "long way around"
+        # And then calculate the longer
         delta_az_long = np.where(delta_az_short < 0, two_pi + delta_az_short, delta_az_short - two_pi)
         # Slew can go long or short direction, but azimuth range
         # could limit which is possible.
         # e.g. 70 degrees reached by going the long way around from 0 means
         # the cumulative azimuth is 290, but if we went the short way it would
-        # be 70 .. actual 'azimuth' is still 70. It also matters about
-        # which direction previous slews went (imagine a previous slew to 180).
-        # First evaluate if azimuth range is > 360 degrees --
+        # be 70 .. absolute azimuth is still 70. Direction of previous
+        # slews is also important.
+        # First evaluate if available azimuth range is > 360 degrees --
         if np.abs(self.telaz_maxpos_rad - self.telaz_minpos_rad) >= two_pi:
             # Can spin past 360 degrees, track cumulative azimuth
             # Note that minpos will be less than maxpos always in this case.
@@ -573,8 +573,7 @@ class KinemModel:
             delta_aztel[out_of_bounds] = np.inf
             az_flag = "restricted"
 
-        # Calculate how long the telescope will take to slew to this
-        # position.
+        # Calculate time to slew to this position.
         tel_alt_slew_time = jerk_time(
             delta_alt, self.telalt_maxspeed_rad, self.telalt_accel_rad, self.telalt_jerk_rad
         )
@@ -636,9 +635,8 @@ class KinemModel:
             tot_dom_time[same_dome] = 0
 
         else:
-            # the above models a dome slit and dome creep. However, it
-            # appears that SOCS requires the dome to slew exactly to each
-            # field and settle in az
+            # the above models a dome slit and dome creep.
+            # If this option is not available however:
             dom_alt_slew_time = jerk_time(
                 delta_alt, self.domalt_maxspeed_rad, self.domalt_accel_rad, self.domalt_jerk_rad
             )

--- a/rubin_scheduler/scheduler/model_observatory/kinem_model.py
+++ b/rubin_scheduler/scheduler/model_observatory/kinem_model.py
@@ -303,7 +303,7 @@ class KinemModel:
         azimuth_maxpos : `float`
             Maximum azimuth position (degrees).
             Note this value is related to cumulative azimuth range,
-            for cable wrap. Defaults -270 and 270 include 0-360
+            for cable wrap. Defaults -250/250 include 0-360
             for all-sky azimuth positions, reachable via multiple
             routes.
         altitude_maxspeed : `float`
@@ -450,7 +450,7 @@ class KinemModel:
             This overrides rot_sky_pos, if set.
             If neither rot_sky_pos nor rot_tel_pos are set, no rotation
             time is added (equivalent to using current rot_tel_pos).
-        filtername : `str`
+        filtername : `str` or None
             The filter(s) of the desired observations.
             Set to None to compute only telescope and dome motion times.
         alt_rad : `np.ndarray`
@@ -564,7 +564,7 @@ class KinemModel:
         # azimuth range < 360 degrees.
         else:
             # Note that minpos will be the starting angle, but
-            # depending on cw/ccw - maxpos might be < minpos.
+            # depending on direction available - maxpos might be < minpos.
             az_range = (self.telaz_maxpos_rad - self.telaz_minpos_rad) % (two_pi)
             out_of_bounds = np.where((az_rad - self.telaz_minpos_rad) % (two_pi) > az_range)[0]
             d1 = (az_rad - self.telaz_minpos_rad) % (two_pi)
@@ -672,7 +672,7 @@ class KinemModel:
         outside_limits = np.where((alt_rad > self.telalt_maxpos_rad) | (alt_rad < self.telalt_minpos_rad))[0]
         slew_time[outside_limits] = np.nan
         # Azimuth limits already masked through cumulative azimuth
-        # calculation above (although it is inf, not nan, so let's swap).
+        # calculation above (it might be inf, not nan, so let's swap).
         slew_time = np.where(np.isfinite(slew_time), slew_time, np.nan)
 
         # If we want to include the camera rotation time

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -302,11 +302,11 @@ class ModelObservatory:
         if tel_alt_limits is not None:
             self.tel_alt_limits = np.radians(tel_alt_limits)
         else:
-            self.tel_alt_limits = []
+            self.tel_alt_limits = None
         if tel_az_limits is not None:
             self.tel_az_limits = np.radians(tel_az_limits)
         else:
-            self.tel_az_limits = []
+            self.tel_az_limits = None
         # Add the observatory alt/az limits to the user-defined limits
         # But we do have to be careful that we're not overriding more
         # restrictive limits that were already set.

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -1,5 +1,6 @@
 __all__ = ("ModelObservatory",)
 
+import copy
 import warnings
 
 import healpy as hp
@@ -311,11 +312,15 @@ class ModelObservatory:
         # But we do have to be careful that we're not overriding more
         # restrictive limits that were already set.
         # So we'll just keep these separate.
-        self.kinematic_tel_alt_limits = [
-            self.observatory.telalt_minpos_rad,
-            self.observatory.telalt_maxpos_rad,
-        ]
-        self.kinematic_tel_az_limits = [self.observatory.telaz_minpos_rad, self.observatory.telaz_maxpos_rad]
+        self.kinematic_tel_alt_limits = copy.deepcopy(
+            [
+                self.observatory.telalt_minpos_rad,
+                self.observatory.telalt_maxpos_rad,
+            ]
+        )
+        self.kinematic_tel_az_limits = copy.deepcopy(
+            [self.observatory.telaz_minpos_rad, self.observatory.telaz_maxpos_rad]
+        )
         # Each of these limits will be treated as hard limits that we don't
         # want pointings to stray into, so add a pad around the values
         self.altaz_limit_pad = np.radians(2.0)

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -126,6 +126,18 @@ class ModelObservatory:
         to the next night. Default "sun_n12_rising", e.g., sun at
         -12 degrees and rising. Other options are "sun_n18_rising"
         and "sunrise".
+    tel_az_limits : `list` [[`float`, `float`]]
+        A list of lists giving valid azimuth ranges. e.g.,
+        [0, 180] would mean all azimuth values are valid, while
+        [[0, 90], [270, 360]] or [270, 90] would mean anywhere in
+        the south is invalid.  Degrees.
+    tel_alt_limits : `list` [[`float`, `float`]]
+        A list of lists giving valid altitude ranges. Degrees.
+        For both the alt and az limits, if a particular alt (or az)
+        value is included in any limit, it is valid for all of them.
+        Altitude limits of [[20, 40], [40, 60]] would allow altitudes
+        betwen 20-40 and 40-60, but [[20, 40], [40, 60], [20, 86]]
+        will allow altitudes anywhere between 20-86 degrees.
     telescope : `str`
         Telescope name for rotation computations. Default "rubin".
     """
@@ -152,6 +164,8 @@ class ModelObservatory:
         wind_data=None,
         starting_time_key="sun_n12_setting",
         ending_time_key="sun_n12_rising",
+        tel_alt_limits=None,
+        tel_az_limits=None,
         telescope="rubin",
     ):
         if nside is None:
@@ -283,6 +297,28 @@ class ModelObservatory:
             self.observatory = KinemModel(mjd0=self.mjd_start)
         else:
             self.observatory = kinem_model
+
+        # Pick up tel alt and az limits from kwargs
+        if tel_alt_limits is not None:
+            self.tel_alt_limits = np.radians(tel_alt_limits)
+        else:
+            self.tel_alt_limits = []
+        if tel_az_limits is not None:
+            self.tel_az_limits = np.radians(tel_az_limits)
+        else:
+            self.tel_az_limits = []
+        # Add the observatory alt/az limits to the user-defined limits
+        # But we do have to be careful that we're not overriding more
+        # restrictive limits that were already set.
+        # So we'll just keep these separate.
+        self.kinematic_tel_alt_limits = [
+            self.observatory.telalt_minpos_rad,
+            self.observatory.telalt_maxpos_rad,
+        ]
+        self.kinematic_tel_az_limits = [self.observatory.telaz_minpos_rad, self.observatory.telaz_maxpos_rad]
+        # Each of these limits will be treated as hard limits that we don't
+        # want pointings to stray into, so add a pad around the values
+        self.altaz_limit_pad = np.radians(2.0)
 
         # Let's make sure we're at an openable MJD
         good_mjd = False
@@ -436,10 +472,11 @@ class ModelObservatory:
         self.conditions.mjd_start = self.mjd_start
 
         # Telescope limits
-        self.conditions.tel_az_min = self.observatory.telaz_minpos_rad
-        self.conditions.tel_az_max = self.observatory.telaz_maxpos_rad
-        self.conditions.tel_alt_min = self.observatory.telalt_minpos_rad
-        self.conditions.tel_alt_max = self.observatory.telalt_maxpos_rad
+        self.conditions.tel_az_limits = self.tel_az_limits
+        self.conditions.tel_alt_limits = self.tel_alt_limits
+        self.conditions.kinematic_alt_limits = self.kinematic_tel_alt_limits
+        self.conditions.kinematic_az_limits = self.kinematic_tel_az_limits
+        self.conditions.altaz_limit_pad = self.altaz_limit_pad
 
         # Planet positions from almanac
         self.conditions.planet_positions = self.almanac.get_planet_positions(self.mjd)

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -345,7 +345,7 @@ class ModelObservatory:
         # Clouds. XXX--just the raw value
         self.conditions.bulk_cloud = self.cloud_data(current_time)
 
-        # use conditions object itself to get aprox altitude of each
+        # use conditions object itself to get approx altitude of each
         # healpx
         alts = self.conditions.alt
         azs = self.conditions.az
@@ -436,8 +436,10 @@ class ModelObservatory:
         self.conditions.mjd_start = self.mjd_start
 
         # Telescope limits
-        self.conditions.tel_az_limits = self.observatory.az_limits
-        self.conditions.tel_alt_limits = self.observatory.alt_limits
+        self.conditions.tel_az_min = self.observatory.telaz_minpos_rad
+        self.conditions.tel_az_max = self.observatory.telaz_maxpos_rad
+        self.conditions.tel_alt_min = self.observatory.telalt_minpos_rad
+        self.conditions.tel_alt_max = self.observatory.telalt_maxpos_rad
 
         # Planet positions from almanac
         self.conditions.planet_positions = self.almanac.get_planet_positions(self.mjd)

--- a/rubin_scheduler/scheduler/sim_runner.py
+++ b/rubin_scheduler/scheduler/sim_runner.py
@@ -149,6 +149,7 @@ def sim_runner(
             # Flush queue and try to get some new targets.
             scheduler.flush_queue()
             mjd_last_flush = copy.deepcopy(observatory.mjd)
+
         if new_night:
             # find out what filters we want mounted
             conditions = observatory.return_conditions()

--- a/rubin_scheduler/scheduler/surveys/scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/scripted_surveys.py
@@ -240,7 +240,7 @@ class ScriptedSurvey(BaseSurvey):
             in_range = in_range[good]
         if np.abs(conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) < (2 * np.pi):
             az_range = (conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) % (2 * np.pi)
-            ir = np.where((az[in_range] - az_min) % (2 * np.pi) <= az_range)[0]
+            ir = np.where((az[in_range] - conditions.kinematic_az_limits[0]) % (2 * np.pi) <= az_range)[0]
             in_range = in_range[ir]
 
         # Check that filter needed is mounted

--- a/rubin_scheduler/scheduler/surveys/scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/scripted_surveys.py
@@ -212,20 +212,36 @@ class ScriptedSurvey(BaseSurvey):
 
         # Also check the alt,az limits given by the conditions object
         count = in_range * 0
-        ir = np.where((alt[in_range] >= conditions.tel_az_min) & (alt[in_range] <= conditions.tel_az_max))[0]
-        count[ir] += 1
-        good = np.where(count > 0)[0]
-        in_range = in_range[good]
+        if conditions.tel_alt_limits is not None:
+            for limits in conditions.tel_alt_limits:
+                ir = np.where((alt[in_range] >= np.min(limits)) & (alt[in_range] <= np.max(limits)))[0]
+                count[ir] += 1
+            good = np.where(count > 0)[0]
+            in_range = in_range[good]
+        # Check against kinematic limits too
+        ir = np.where(
+            (alt[in_range] >= np.min(conditions.kinematic_alt_limits))
+            & (alt[in_range] <= np.max(conditions.kinematic_alt_limits))
+        )[0]
+        in_range = in_range[ir]
 
         count = in_range * 0
-        if (conditions.tel_az_max - conditions.tel_az_min) >= (2 * np.pi):
-            count += 1
-        else:
-            az_range = (conditions.tel_az_max - conditions.tel_az_min) % (2 * np.pi)
-            ir = np.where((az[in_range] - conditions.tel_az_min) % (2 * np.pi) <= az_range)[0]
-            count[ir] += 1
-        good = np.where(count > 0)[0]
-        in_range = in_range[good]
+        if conditions.tel_az_limits is not None:
+            for limits in conditions.tel_az_limits:
+                az_min = limits[0]
+                az_max = limits[1]
+                if np.abs(az_max - az_min) >= (2 * np.pi):
+                    count += 1
+                else:
+                    az_range = (az_max - az_min) % (2 * np.pi)
+                    ir = np.where((az[in_range] - az_min) % (2 * np.pi) <= az_range)[0]
+                    count[ir] += 1
+            good = np.where(count > 0)[0]
+            in_range = in_range[good]
+        if np.abs(conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) < (2 * np.pi):
+            az_range = (conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) % (2 * np.pi)
+            ir = np.where((az[in_range] - az_min) % (2 * np.pi) <= az_range)[0]
+            in_range = in_range[ir]
 
         # Check that filter needed is mounted
         good = np.isin(observation["filter"][in_range], conditions.mounted_filters)

--- a/rubin_scheduler/scheduler/surveys/scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/scripted_surveys.py
@@ -212,15 +212,17 @@ class ScriptedSurvey(BaseSurvey):
 
         # Also check the alt,az limits given by the conditions object
         count = in_range * 0
-        for limits in conditions.tel_alt_limits:
-            ir = np.where((alt[in_range] >= np.min(limits)) & (alt[in_range] <= np.max(limits)))[0]
-            count[ir] += 1
+        ir = np.where((alt[in_range] >= conditions.tel_az_min) & (alt[in_range] <= conditions.tel_az_max))[0]
+        count[ir] += 1
         good = np.where(count > 0)[0]
         in_range = in_range[good]
 
         count = in_range * 0
-        for limits in conditions.tel_az_limits:
-            ir = np.where((az[in_range] >= np.min(limits)) & (az[in_range] <= np.max(limits)))[0]
+        if (conditions.tel_az_max - conditions.tel_az_min) >= (2 * np.pi):
+            count += 1
+        else:
+            az_range = (conditions.tel_az_max - conditions.tel_az_min) % (2 * np.pi)
+            ir = np.where((az[in_range] - conditions.tel_az_min) % (2 * np.pi) <= az_range)[0]
             count[ir] += 1
         good = np.where(count > 0)[0]
         in_range = in_range[good]

--- a/rubin_scheduler/scheduler/surveys/surveys.py
+++ b/rubin_scheduler/scheduler/surveys/surveys.py
@@ -211,6 +211,8 @@ class BlobSurvey(GreedySurvey):
 
         if survey_name is None:
             self._generate_survey_name()
+        else:
+            self.survey_name = survey_name
 
         if scheduler_note is None:
             if survey_note is not None:

--- a/rubin_scheduler/utils/site.py
+++ b/rubin_scheduler/utils/site.py
@@ -2,7 +2,9 @@ __all__ = ("Site",)
 
 import warnings
 
+import astropy.units as u
 import numpy as np
+from astropy.coordinates import EarthLocation
 
 
 class LsstSiteParameters:
@@ -169,6 +171,11 @@ class Site:
             msg += "If you want these to just default to LSST values,\n"
             msg += "instantiate your Site with name='LSST'"
             warnings.warn(msg)
+
+    def to_earth_location(self):
+        return EarthLocation.from_geodetic(
+            lon=self.longitude * u.deg, lat=self.latitude * u.deg, height=self.height * u.meter
+        )
 
     def __eq__(self, other):
         for param in self.__dict__:

--- a/tests/scheduler/test_basisfuncs.py
+++ b/tests/scheduler/test_basisfuncs.py
@@ -191,7 +191,6 @@ class TestBasis(unittest.TestCase):
             basis_functions.AvoidLongGapsBasisFunction,
             basis_functions.FootprintNvisBasisFunction,
             basis_functions.GoalStrictFilterBasisFunction,
-            basis_functions.ZenithMaskBasisFunction,
             basis_functions.ZenithShadowMaskBasisFunction,
             basis_functions.MaskAzimuthBasisFunction,
         ]

--- a/tests/scheduler/test_basisfuncs.py
+++ b/tests/scheduler/test_basisfuncs.py
@@ -6,8 +6,6 @@ import numpy as np
 import rubin_scheduler.scheduler.basis_functions as basis_functions
 from rubin_scheduler.scheduler.features import Conditions
 from rubin_scheduler.scheduler.utils import empty_observation
-from rubin_scheduler.scheduler.utils import generate_all_sky
-from rubin_scheduler.utils import _approx_ra_dec2_alt_az
 
 
 class TestBasis(unittest.TestCase):

--- a/tests/scheduler/test_basisfuncs.py
+++ b/tests/scheduler/test_basisfuncs.py
@@ -6,6 +6,8 @@ import numpy as np
 import rubin_scheduler.scheduler.basis_functions as basis_functions
 from rubin_scheduler.scheduler.features import Conditions
 from rubin_scheduler.scheduler.utils import empty_observation
+from rubin_scheduler.scheduler.utils import generate_all_sky
+from rubin_scheduler.utils import _approx_ra_dec2_alt_az
 
 
 class TestBasis(unittest.TestCase):
@@ -183,6 +185,150 @@ class TestBasis(unittest.TestCase):
         conditions.sun_n12_rising = conditions.mjd + 16.0 / 60 / 24
         conditions.sun_alt = -20
         assert ~bf.check_feasibility(conditions)
+
+    def test_AltAzShadowMask(self):
+        nside = 32
+        conditions = Conditions(nside=nside)
+        conditions.mjd = 59000.0
+        conditions.altaz_limit_pad = np.radians(2.0)
+        conditions.kinematic_az_limits = [np.radians(-250), np.radians(250)]
+        conditions.kinematic_alt_limits = [np.radians(-100), np.radians(100)]
+        # With no (real) limits, including no limits in conditions
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=0, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        self.assertTrue(np.all(np.isnan(result[np.where(conditions.alt < 0)])))
+        self.assertTrue(np.all(result[np.where(conditions.alt >= 0)] == 0))
+        # Set altitude limits
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=40, max_alt=60, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        good = np.where((conditions.alt > np.radians(40)) & (conditions.alt < np.radians(60)), True, False)
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # And set azimuth limits
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=-90, max_alt=90, min_az=90, max_az=180, shadow_minutes=0
+        )
+        result = bf(conditions)
+        good = np.where((conditions.az > np.radians(90)) & (conditions.az < np.radians(180)), True, False)
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # And set azimuth limits - order sensitive
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=-90, max_alt=90, min_az=180, max_az=90, shadow_minutes=0
+        )
+        result = bf(conditions)
+        good = np.where((conditions.az > np.radians(180)) | (conditions.az < np.radians(90)), True, False)
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # And set altitude limits from the conditions
+        conditions.tel_alt_limits = [[np.radians(40), np.radians(60)]]
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=0, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        good = np.where((conditions.alt > np.radians(42)) & (conditions.alt < np.radians(58)), True, False)
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # Set multiple altitude limits from the conditions
+        conditions.tel_alt_limits = [[np.radians(40), np.radians(60)], [np.radians(80), np.radians(90)]]
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        # Conditions value get padded
+        good = np.where(
+            ((conditions.alt > np.radians(42)) & (conditions.alt < np.radians(58)))
+            | ((conditions.alt > np.radians(82)) & (conditions.alt < np.radians(88))),
+            True,
+            False,
+        )
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # Set azimuth limits
+        conditions.tel_alt_limits = None
+        conditions.tel_az_limits = [[np.radians(270), np.radians(90)]]
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        # Conditions value get padded, but we should be able to mask this area
+        # at a minimum
+        good = np.where(
+            (conditions.az > np.radians(270)) | (conditions.az < np.radians(90)),
+            True,
+            False,
+        )
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        # Set azimuth limits, direction sensitive
+        conditions.tel_alt_limits = None
+        conditions.tel_az_limits = [[np.radians(90), np.radians(270)]]
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        good = np.where(
+            (conditions.az < np.radians(268)) & (conditions.az > np.radians(92)),
+            True,
+            False,
+        )
+        # Check this area is masked
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # Set altitude limits from kinematic model
+        conditions.tel_alt_limits = None
+        conditions.kinematic_alt_limits = [np.radians(20), np.radians(86.5)]
+        conditions.tel_az_limits = None
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        good = np.where(
+            (conditions.alt > np.radians(22)) & (conditions.alt < np.radians(84.5)),
+            True,
+            False,
+        )
+        # Check this area is masked
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # Set azimuth limits from kinematic model
+        conditions.tel_alt_limits = None
+        conditions.tel_az_limits = None
+        conditions.kinematic_az_limits = [np.radians(90), np.radians(270)]
+        conditions.kinematic_alt_limits = [np.radians(-100), np.radians(100)]
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        good = np.where(
+            (conditions.az < np.radians(268)) & (conditions.az > np.radians(92)),
+            True,
+            False,
+        )
+        # Check this area is masked
+        self.assertTrue(np.all(np.isnan(result[~good])))
+        self.assertTrue(np.all(result[good] == 0))
+        # Check very simple shadow minutes
+        # Set azimuth limits from kinematic model
+        conditions.tel_alt_limits = None
+        conditions.tel_az_limits = None
+        conditions.kinematic_az_limits = [np.radians(-250), np.radians(250)]
+        conditions.kinematic_alt_limits = [np.radians(-100), np.radians(100)]
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=20, max_alt=85, min_az=0, max_az=360, shadow_minutes=0
+        )
+        result = bf(conditions)
+        bf = basis_functions.AltAzShadowMaskBasisFunction(
+            nside=nside, min_alt=20, max_alt=85, min_az=0, max_az=360, shadow_minutes=30
+        )
+        result_shadow = bf(conditions)
+        overlap = np.where(np.isnan(result) & ~np.isnan(result_shadow))
+        self.assertTrue(len(overlap[0]) == 0)
+        overlap = np.where(np.isnan(result_shadow) & ~np.isnan(result))
+        self.assertTrue(len(overlap[0]) > 0)
 
     def test_deprecated(self):
         deprecated_basis_functions = [

--- a/tests/scheduler/test_basisfuncs.py
+++ b/tests/scheduler/test_basisfuncs.py
@@ -195,6 +195,7 @@ class TestBasis(unittest.TestCase):
             basis_functions.MaskAzimuthBasisFunction,
         ]
         for dep_bf in deprecated_basis_functions:
+            print(dep_bf)
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 dep_bf()

--- a/tests/scheduler/test_basisfuncs.py
+++ b/tests/scheduler/test_basisfuncs.py
@@ -191,6 +191,9 @@ class TestBasis(unittest.TestCase):
             basis_functions.AvoidLongGapsBasisFunction,
             basis_functions.FootprintNvisBasisFunction,
             basis_functions.GoalStrictFilterBasisFunction,
+            basis_functions.ZenithMaskBasisFunction,
+            basis_functions.ZenithShadowMaskBasisFunction,
+            basis_functions.MaskAzimuthBasisFunction,
         ]
         for dep_bf in deprecated_basis_functions:
             with warnings.catch_warnings(record=True) as w:

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -105,9 +105,8 @@ class TestUtils(unittest.TestCase):
         mjd_start = survey_start_mjd()
         scheduler = example_scheduler(mjd_start=mjd_start)
         km = KinemModel(mjd0=mjd_start)
-        km.setup_telescope(az_limits=[[0.0, 90.0], [270.0, 360.0]])
-        mo = ModelObservatory(mjd_start=mjd_start, kinem_model=km)
-
+        km.setup_telescope(abs_azimuth_minpos=270, abs_azimuth_maxpos=90)
+        mo = ModelObservatory(mjd=mjd_start, mjd_start=mjd_start, kinem_model=km)
         mo, scheduler, observations = sim_runner(
             mo,
             scheduler,
@@ -117,6 +116,7 @@ class TestUtils(unittest.TestCase):
         )
 
         az = np.degrees(observations["az"])
+        forbidden = np.where((az > 90) & (az < 270))[0]
 
         # Let a few pairs try to complete since by default we don't
         # use an agressive shadow_minutes
@@ -125,8 +125,9 @@ class TestUtils(unittest.TestCase):
         assert forbidden.size == 0
 
         km = KinemModel(mjd0=mjd_start)
-        km.setup_telescope(alt_limits=[[40.0, 70.0]])
-        mo = ModelObservatory(mjd_start=mjd_start, kinem_model=km)
+        km.setup_telescope(altitude_minpos=40.0, altitude_maxpos=70.0)
+        mo = ModelObservatory(mjd=observations[-1]["mjd"], mjd_start=mjd_start, kinem_model=km)
+        scheduler.flush_queue()
 
         mo, scheduler, observations = sim_runner(
             mo,
@@ -137,7 +138,6 @@ class TestUtils(unittest.TestCase):
         )
         alt = np.degrees(observations["alt"])
         n_forbidden = np.size(np.where((alt > 70) & (alt < 40))[0])
-
         assert n_forbidden == 0
 
     def test_restore(self):

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -63,7 +63,6 @@ class TestUtils(unittest.TestCase):
             "pair_33, gr, a",
             "pair_33, gr, b",
             "pair_33, ri, a",
-            "pair_33, ri, b",
             "pair_33, ug, a",
             "pair_33, ug, b",
             "pair_33, yy, a",


### PR DESCRIPTION
I expect this PR could have downstream effects on what is scheduled .. depending on how the observatory kinematic model is set up. 
For a fully functioning telescope, with >360 degrees of rotator azimuth range, I don't think it would have that much of an effect. However, it's also true that if we're bumping up against the cumulative azimuth range, this might be an incorrect statement. Depends on the configuration of the AltAzShadowMaskBasisFunction itself during use. 
The kinematic model will now return valid slew times over the parts of the sky which are valid, if provided "no filter" or if given rotSkyPos. This again should have no effect on the actual operations of the kinematic model during baseline sim_runner use, but is useful when trying to diagnose issues later or to just investigate possible slew times. 