### PR TITLE
PREOPS-5366: remove old minimum pair time kwarg since blob no longer adjust pair time

### DIFF
--- a/rubin_scheduler/scheduler/surveys/surveys.py
+++ b/rubin_scheduler/scheduler/surveys/surveys.py
@@ -123,8 +123,6 @@ class BlobSurvey(GreedySurvey):
     ideal_pair_time : `float`
         The ideal time gap wanted between observations to the same
         pointing (minutes)
-    min_pair_time : `float`
-        The minimum acceptable pair time (minutes)
     flush_time : `float`
         The time past the final expected exposure to flush the queue.
         Keeps observations from lingering past when they should be
@@ -164,7 +162,6 @@ class BlobSurvey(GreedySurvey):
         nexp=2,
         nexp_dict=None,
         ideal_pair_time=22.0,
-        min_pair_time=15.0,
         flush_time=30.0,
         smoothing_kernel=None,
         nside=None,
@@ -228,10 +225,10 @@ class BlobSurvey(GreedySurvey):
         # then repeat.)
         if filtername2 is not None:
             self.time_needed = (
-                (min_pair_time * 60.0 * 2.0 + exptime + read_approx + filter_change_approx) / 24.0 / 3600.0
+                (ideal_pair_time * 60.0 * 2.0 + exptime + read_approx + filter_change_approx) / 24.0 / 3600.0
             )  # Days
         else:
-            self.time_needed = (min_pair_time * 60.0 + exptime + read_approx) / 24.0 / 3600.0  # Days
+            self.time_needed = (ideal_pair_time * 60.0 + exptime + read_approx) / 24.0 / 3600.0  # Days
         self.filter_set = set(filtername1)
         if filtername2 is None:
             self.filter2_set = self.filter_set
@@ -242,7 +239,6 @@ class BlobSurvey(GreedySurvey):
 
         self.survey_note = survey_note
         self.counter = 1  # start at 1, because 0 is default in empty obs
-        self.min_pair_time = min_pair_time
         self.ideal_pair_time = ideal_pair_time
 
         self.pixarea = hp.nside2pixarea(self.nside, degrees=True)
@@ -473,10 +469,8 @@ class BlobSurvey(GreedySurvey):
         # the nearest/fastest slew from current position.
         observations = []
         counter2 = 0
-        approx_end_time = np.size(better_order) * (
-            self.slew_approx + self.exptime + self.read_approx * (self.nexp - 1)
-        )
-        flush_time = conditions.mjd + approx_end_time / 3600.0 / 24.0 + self.flush_time
+        flush_time = conditions.mjd + self.time_needed + self.flush_time
+
         for i, indx in enumerate(better_order):
             field = self.best_fields[indx]
             obs = empty_observation()
@@ -496,5 +490,4 @@ class BlobSurvey(GreedySurvey):
             counter2 += 1
 
         result = observations
-
         return result

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -59,14 +59,16 @@ class TestUtils(unittest.TestCase):
             "pair_15, ri, b",
             "pair_15, yy, a",
             "pair_15, yy, b",
-            "pair_15, zy, a",
             "pair_33, gr, a",
             "pair_33, gr, b",
             "pair_33, ri, a",
+            "pair_33, ri, b",
             "pair_33, ug, a",
             "pair_33, ug, b",
             "pair_33, yy, a",
             "pair_33, yy, b",
+            "pair_33, zy, a",
+            "pair_33, zy, b",
             "twilight_near_sun, 0",
             "twilight_near_sun, 1",
             "twilight_near_sun, 2",
@@ -117,9 +119,8 @@ class TestUtils(unittest.TestCase):
 
         # Let a few pairs try to complete since by default we don't
         # use an agressive shadow_minutes
-        pad = 2
+        pad = 4
         forbidden = np.where((az > 90 + pad) & (az < 270 - pad))[0]
-
         assert forbidden.size == 0
 
         km = KinemModel(mjd0=mjd_start)


### PR DESCRIPTION
Fix issue where flush times were being set too short (because they were being computed in two places).