### PR TITLE
OPSIM-1192: make_rolling_footprint work with default values

### DIFF
--- a/rubin_scheduler/scheduler/utils/sky_area.py
+++ b/rubin_scheduler/scheduler/utils/sky_area.py
@@ -21,9 +21,8 @@ from shapely.geometry import Point
 from shapely.geometry.polygon import Polygon
 
 from rubin_scheduler import data as rs_data
-from rubin_scheduler.utils import Site, _angular_separation, angular_separation
+from rubin_scheduler.utils import Site, _angular_separation, _hpid2_ra_dec, angular_separation
 
-from .footprints import ra_dec_hp_map
 from .utils import IntRounded, set_default_nside
 
 
@@ -84,7 +83,7 @@ def generate_all_sky(nside=None, elevation_limit=20, mask=hp.UNSEEN):
 
     # Calculate coordinates of everything.
     skymap = np.zeros(hp.nside2npix(nside), float)
-    ra, dec = ra_dec_hp_map(nside=nside)
+    ra, dec = _hpid2_ra_dec(nside, np.arange(hp.nside2npix(nside)))(nside=nside)
     coord = SkyCoord(ra=ra * u.rad, dec=dec * u.rad, frame="icrs")
     eclip_lat = coord.barycentrictrueecliptic.lat.deg
     eclip_lon = coord.barycentrictrueecliptic.lon.deg

--- a/tests/scheduler/test_skyarea.py
+++ b/tests/scheduler/test_skyarea.py
@@ -4,7 +4,12 @@ import unittest
 import numpy as np
 
 from rubin_scheduler.data import get_data_dir
-from rubin_scheduler.scheduler.utils import EuclidOverlapFootprint, SkyAreaGenerator, SkyAreaGeneratorGalplane
+from rubin_scheduler.scheduler.utils import (
+    EuclidOverlapFootprint,
+    SkyAreaGenerator,
+    SkyAreaGeneratorGalplane,
+    make_rolling_footprints,
+)
 
 datadir = os.path.join(get_data_dir(), "scheduler")
 
@@ -12,6 +17,33 @@ datadir = os.path.join(get_data_dir(), "scheduler")
 class TestSkyArea(unittest.TestCase):
     def setUp(self):
         self.nside = 32
+
+    def test_make_rolling(self):
+        """Check that we can make rolling footprints"""
+        # Check that we can run with no kwargs
+        footprints = make_rolling_footprints()
+
+        assert footprints is not None
+
+        # check that various kwarg combos work
+        for nslice in [2, 3]:
+            for uniform in [True, False]:
+                for order_roll in [0, 1]:
+                    for n_cycles in [3, 4]:
+                        footprints = make_rolling_footprints(
+                            nslice=nslice,
+                            scale=0.8,
+                            nside=32,
+                            wfd_indx=None,
+                            order_roll=order_roll,
+                            n_cycles=n_cycles,
+                            n_constant_start=2,
+                            n_constant_end=6,
+                            verbose=False,
+                            uniform=uniform,
+                        )
+
+                        assert footprints is not None
 
     @unittest.skipUnless(os.path.isdir(datadir), "Test data not available.")
     def test_skyareagenerator(self):


### PR DESCRIPTION
`make_rolling_footprint` now works with default kwarg values. Had to shuffle a few things around to avoid circular imports. Removed a strange duplicate `_is_in_ra_range` function (strange ruff never noticed that). Added bare-bones unit test for `make_rolling_footprint`.