### PR TITLE
OPSIM-1196: more cleanup for summit use

### DIFF
--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -947,11 +947,6 @@ class SlewtimeBasisFunction(BaseBasisFunction):
         self.nside = nside
         self.filtername = filtername
 
-    def add_observation(self, observation, indx=None):
-        # No tracking of observations in this basis function.
-        # Purely based on conditions.
-        pass
-
     def _calc_value(self, conditions, indx=None):
         # If we are in a different filter, the
         # FilterChangeBasisFunction will take it

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -1364,7 +1364,7 @@ class VisitGap(BaseBasisFunction):
         self.survey_features = dict()
         if self.filter_names is not None:
             for filtername in self.filter_names:
-                self.survey_features[f"LastObservationMjd::{filtername}"] = features.NoteLastObserved(
+                self.survey_features[f"LastObservationMjd::{filtername}"] = features.LastObservationMjd(
                     note=note, filtername=filtername
                 )
         else:

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -1336,7 +1336,7 @@ class VisitGap(BaseBasisFunction):
 
     Parameters
     ----------
-    note : str
+    note : `str`
         Value of the observation "scheduler_note" field to be masked.
     filter_names : list [str], optional
         List of filter names that will be considered when evaluating
@@ -1364,11 +1364,11 @@ class VisitGap(BaseBasisFunction):
         self.survey_features = dict()
         if self.filter_names is not None:
             for filtername in self.filter_names:
-                self.survey_features[f"NoteLastObserved::{filtername}"] = features.NoteLastObserved(
+                self.survey_features[f"LastObservationMjd::{filtername}"] = features.NoteLastObserved(
                     note=note, filtername=filtername
                 )
         else:
-            self.survey_features["NoteLastObserved"] = features.NoteLastObserved(note=note)
+            self.survey_features["LastObservationMjd"] = features.LastObservationMjd(scheduler_note=note)
 
     def check_feasibility(self, conditions):
         notes_last_observed = [last_observed.feature for last_observed in self.survey_features.values()]

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -1452,8 +1452,8 @@ class BalanceVisits(BaseBasisFunction):
         self.nobs_reference = nobs_reference
 
         self.survey_features = {}
-        self.survey_features["n_obs_survey"] = features.NObsCount(note=note_survey)
-        self.survey_features["n_obs_survey_interest"] = features.NObsCount(note=note_interest)
+        self.survey_features["n_obs_survey"] = features.NObsCount(scheduler_note=note_survey)
+        self.survey_features["n_obs_survey_interest"] = features.NObsCount(scheduler_note=note_interest)
 
     def _calc_value(self, conditions, indx=None):
         return (1 + np.floor(self.survey_features["n_obs_survey_interest"].feature / self.nobs_reference)) / (
@@ -1488,7 +1488,7 @@ class RewardNObsSequence(BaseBasisFunction):
         self.n_obs_survey = n_obs_survey
 
         self.survey_features = {}
-        self.survey_features["n_obs_survey"] = features.NObsCount(note=note_survey)
+        self.survey_features["n_obs_survey"] = features.NObsCount(scheduler_note=note_survey)
 
     def _calc_value(self, conditions, indx=None):
         return self.survey_features["n_obs_survey"].feature % self.n_obs_survey

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -678,7 +678,7 @@ class AvoidFastRevisitsBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
-    filtername: `str` or None
+    filtername : `str` or None
         The name of the filter for this target map.
         Using None will match visits in any filter.
     gap_min : `float`
@@ -984,7 +984,7 @@ class CadenceEnhanceBasisFunction(BaseBasisFunction):
         (days)
     apply_area : healpix map
         The area over which to try and drive the cadence.
-        Good values as 1, no candece drive 0.
+        Good values as 1, no cadence drive 0.
         Probably works as a bool array too.
     """
 

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -264,12 +264,13 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         # disjoint allowable areas, while the tel_alt_limits are a single
         # wide set of allowable area which explicitly disallows anything
         # outside that range. The az limits versions are similar.
-        min_alt = IntRounded(conditions.tel_alt_limits[0] + self.altaz_limit_pad)
-        max_alt = IntRounded(conditions.tel_alt_limits[1] - self.altaz_limit_pad)
-        result[np.where(r_current_alt < min_alt)] = np.nan
-        result[np.where(r_current_alt > max_alt)] = np.nan
-        result[np.where(r_future_alt < min_alt)] = np.nan
-        result[np.where(r_future_alt > max_alt)] = np.nan
+        if conditions.tel_alt_limits is not None:
+            min_alt = IntRounded(conditions.tel_alt_limits[0] + self.altaz_limit_pad)
+            max_alt = IntRounded(conditions.tel_alt_limits[1] - self.altaz_limit_pad)
+            result[np.where(r_current_alt < min_alt)] = np.nan
+            result[np.where(r_current_alt > max_alt)] = np.nan
+            result[np.where(r_future_alt < min_alt)] = np.nan
+            result[np.where(r_future_alt > max_alt)] = np.nan
 
         # note that % (mod) is not supported for IntRounded
         two_pi = 2 * np.pi
@@ -300,18 +301,19 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
                 combined += in_bounds
             result[np.where(combined == 0)] = np.nan
         # Check against the kinematic hard limits.
-        if np.abs(conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) < two_pi:
-            az_range = (conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) % (
-                two_pi
-            ) - self.altaz_limit_pad * 2
-            out_of_bounds = np.where(
-                (conditions.az - conditions.tel_az_limits[0] - self.altaz_limit_pad) % (two_pi) > az_range
-            )[0]
-            result[out_of_bounds] = np.nan
-            out_of_bounds = np.where(
-                (future_az - conditions.tel_az_limits[0] - self.altaz_limit_pad) % (two_pi) > az_range
-            )[0]
-            result[out_of_bounds] = np.nan
+        if conditions.tel_az_limits is not None:
+            if np.abs(conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) < two_pi:
+                az_range = (conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) % (
+                    two_pi
+                ) - self.altaz_limit_pad * 2
+                out_of_bounds = np.where(
+                    (conditions.az - conditions.tel_az_limits[0] - self.altaz_limit_pad) % (two_pi) > az_range
+                )[0]
+                result[out_of_bounds] = np.nan
+                out_of_bounds = np.where(
+                    (future_az - conditions.tel_az_limits[0] - self.altaz_limit_pad) % (two_pi) > az_range
+                )[0]
+                result[out_of_bounds] = np.nan
 
         return result
 

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -170,7 +170,7 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
      regions which will enter the mask within `shadow_minutes`.
 
     Masks any alt/az regions as specified by the conditions object in
-    `conditions.tel_az_limits` and `conditions.tel_alt_limits`,
+    `conditions.sky_az_limits` and `conditions.sky_alt_limits`,
     as well as values as provided by `min_alt`, `max_alt`,
     `min_az` and `max_az`.
 
@@ -197,6 +197,11 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         For sequences, try the length of the sequence + some buffer.
         Note that this just sets up the shadow *at* the shadow_minutes time
         (and not all times up to shadow_minutes).
+    altaz_limit_pad : `float`
+        The value by which to pad the telescope limits, to avoid
+        healpix values mapping into pointings from the field tesselations
+        which are actually out of bounds. This should typically be
+        a bit more than the radius of the fov.  (degrees).
     """
 
     def __init__(
@@ -207,6 +212,7 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         min_az=0,
         max_az=360,
         shadow_minutes=40.0,
+        altaz_limit_pad=2.0,
     ):
         super().__init__(nside=nside)
         self.min_alt = np.radians(min_alt)
@@ -214,6 +220,7 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         self.min_az = np.radians(min_az)
         self.max_az = np.radians(max_az)
         self.shadow_time = shadow_minutes / 60.0 / 24.0  # To days
+        self.altaz_limit_pad = np.radians(altaz_limit_pad)
 
         self.r_min_alt = IntRounded(self.min_alt)
         self.r_max_alt = IntRounded(self.max_alt)
@@ -235,25 +242,30 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
         result[np.where(r_current_alt > self.r_max_alt)] = np.nan
         result[np.where(r_future_alt < self.r_min_alt)] = np.nan
         result[np.where(r_future_alt > self.r_max_alt)] = np.nan
-        # Check the conditions objects altitude limits, now and future
-        if (conditions.tel_alt_limits is not None) and (len(conditions.tel_alt_limits) > 0):
+
+        # Check the conditions objects 'sky_alt_limit', now and future
+        if (conditions.sky_alt_limits is not None) and (len(conditions.sky_alt_limits) > 0):
             combined = np.zeros(hp.nside2npix(self.nside), dtype=float)
-            for limits in conditions.tel_alt_limits:
+            for limits in conditions.sky_alt_limits:
                 # For conditions-based limits, must add pad
                 # And remember that discontinuous areas can be allowed
                 in_bounds = np.ones(hp.nside2npix(self.nside), dtype=float)
-                min_alt = IntRounded(limits[0] + conditions.altaz_limit_pad)
-                max_alt = IntRounded(limits[1] - conditions.altaz_limit_pad)
+                min_alt = IntRounded(limits[0] + self.altaz_limit_pad)
+                max_alt = IntRounded(limits[1] - self.altaz_limit_pad)
                 in_bounds[np.where(r_current_alt < min_alt)] = 0
                 in_bounds[np.where(r_current_alt > max_alt)] = 0
                 in_bounds[np.where(r_future_alt < min_alt)] = 0
                 in_bounds[np.where(r_future_alt > max_alt)] = 0
                 combined += in_bounds
             result[np.where(combined == 0)] = np.nan
-        # And check against the kinematic hard limits.
-        # These are separate so they don't override user tel_alt_limits.
-        min_alt = IntRounded(conditions.kinematic_alt_limits[0] + conditions.altaz_limit_pad)
-        max_alt = IntRounded(conditions.kinematic_alt_limits[1] - conditions.altaz_limit_pad)
+        # And check against the telescope 'tel_alt_limits'.
+        # The tel_alt_limits could be combined with the sky_alt_limits,
+        # but it's a bit tricky because sky_alt_limits are (potentially)
+        # disjoint allowable areas, while the tel_alt_limits are a single
+        # wide set of allowable area which explicitly disallows anything
+        # outside that range. The az limits versions are similar.
+        min_alt = IntRounded(conditions.tel_alt_limits[0] + self.altaz_limit_pad)
+        max_alt = IntRounded(conditions.tel_alt_limits[1] - self.altaz_limit_pad)
         result[np.where(r_current_alt < min_alt)] = np.nan
         result[np.where(r_current_alt > max_alt)] = np.nan
         result[np.where(r_future_alt < min_alt)] = np.nan
@@ -269,37 +281,35 @@ class AltAzShadowMaskBasisFunction(BaseBasisFunction):
             out_of_bounds = np.where((future_az - self.min_az) % (two_pi) > az_range)[0]
             result[out_of_bounds] = np.nan
         # Check the conditions objects azimuth limits, now and future
-        if (conditions.tel_az_limits is not None) and (len(conditions.tel_az_limits) > 0):
+        if (conditions.sky_az_limits is not None) and (len(conditions.sky_az_limits) > 0):
             combined = np.zeros(hp.nside2npix(self.nside), dtype=float)
-            for limits in conditions.tel_az_limits:
+            for limits in conditions.sky_az_limits:
                 in_bounds = np.ones(hp.nside2npix(self.nside), dtype=float)
                 min_az = limits[0]
                 max_az = limits[1]
                 if np.abs(max_az - min_az) < two_pi:
-                    az_range = (max_az - min_az) % (two_pi) - 2 * conditions.altaz_limit_pad
+                    az_range = (max_az - min_az) % (two_pi) - 2 * self.altaz_limit_pad
                     out_of_bounds = np.where(
-                        (conditions.az - min_az - conditions.altaz_limit_pad) % (two_pi) > az_range
+                        (conditions.az - min_az - self.altaz_limit_pad) % (two_pi) > az_range
                     )[0]
                     in_bounds[out_of_bounds] = 0
                     out_of_bounds = np.where(
-                        (future_az - min_az - conditions.altaz_limit_pad) % (two_pi) > az_range
+                        (future_az - min_az - self.altaz_limit_pad) % (two_pi) > az_range
                     )[0]
                     in_bounds[out_of_bounds] = 0
                 combined += in_bounds
             result[np.where(combined == 0)] = np.nan
         # Check against the kinematic hard limits.
-        if np.abs(conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) < two_pi:
-            az_range = (conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) % (
+        if np.abs(conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) < two_pi:
+            az_range = (conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) % (
                 two_pi
-            ) - conditions.altaz_limit_pad * 2
+            ) - self.altaz_limit_pad * 2
             out_of_bounds = np.where(
-                (conditions.az - conditions.kinematic_az_limits[0] - conditions.altaz_limit_pad) % (two_pi)
-                > az_range
+                (conditions.az - conditions.tel_az_limits[0] - self.altaz_limit_pad) % (two_pi) > az_range
             )[0]
             result[out_of_bounds] = np.nan
             out_of_bounds = np.where(
-                (future_az - conditions.kinematic_az_limits[0] - conditions.altaz_limit_pad) % (two_pi)
-                > az_range
+                (future_az - conditions.tel_az_limits[0] - self.altaz_limit_pad) % (two_pi) > az_range
             )[0]
             result[out_of_bounds] = np.nan
 

--- a/rubin_scheduler/scheduler/example/simple_examples.py
+++ b/rubin_scheduler/scheduler/example/simple_examples.py
@@ -669,12 +669,17 @@ def simple_greedy_survey(
 
 
 def simple_rewards_field_survey(
-    nside: int = DEFAULT_NSIDE, sun_alt_limit: float = -12.0
+    scheduler_note: str,
+    nside: int = DEFAULT_NSIDE,
+    sun_alt_limit: float = -12.0,
 ) -> list[basis_functions.BaseBasisFunction]:
     """Get some simple rewards to observe a field survey for a long period.
 
     Parameters
     ----------
+    scheduler_note : `str`
+        The scheduler note for the field survey.
+        Typically this will be the same as the field name.
     nside : `int`
         The nside value for the healpix grid.
     sun_alt_limit : `float`, optional
@@ -687,8 +692,8 @@ def simple_rewards_field_survey(
     """
     bfs = [
         basis_functions.NotTwilightBasisFunction(sun_alt_limit=sun_alt_limit),
-        # Avoid revisits within 30 minutes
-        basis_functions.AvoidFastRevisitsBasisFunction(nside=nside, filtername=None, gap_min=30.0),
+        # Avoid revisits within 30 minutes - but we'll have to replace "note"
+        basis_functions.VisitGap(filter_names=None, note=scheduler_note, gap_min=30.0),
         # reward fields which are rising, but don't mask out after zenith
         basis_functions.RewardRisingBasisFunction(nside=nside, slope=0.1, penalty_val=0),
         # Reward parts of the sky which are darker --
@@ -775,7 +780,7 @@ def simple_field_survey(
     if mask_basis_functions is None:
         mask_basis_functions = standard_masks(nside=nside)
     if reward_basis_functions is None:
-        reward_basis_functions = simple_rewards_field_survey(nside=nside)
+        reward_basis_functions = simple_rewards_field_survey(field_name, nside=nside)
     basis_functions = mask_basis_functions + reward_basis_functions
 
     if nvisits is None:
@@ -794,7 +799,6 @@ def simple_field_survey(
         exptimes=exptimes,
         nexps=nexps,
         ignore_obs=None,
-        accept_obs=[field_name],
         survey_name=field_name,
         scheduler_note=field_name,
         target_name=field_name,

--- a/rubin_scheduler/scheduler/example/simple_examples.py
+++ b/rubin_scheduler/scheduler/example/simple_examples.py
@@ -30,6 +30,7 @@ from rubin_scheduler.utils import DEFAULT_NSIDE, SURVEY_START_MJD
 
 
 def get_ideal_model_observatory(
+    nside: int = DEFAULT_NSIDE,
     dayobs: str = "2024-09-09",
     fwhm_500: float = 1.6,
     wind_speed: float = 5.0,
@@ -48,6 +49,8 @@ def get_ideal_model_observatory(
 
     Parameters
     ----------
+    nside : `int`
+        The nside for the model observatory.
     dayobs : `str`
         DAYOBS formatted str (YYYY-MM-DD) for the evening to start
         up the observatory.
@@ -103,6 +106,7 @@ def get_ideal_model_observatory(
 
     # Set up the model observatory
     observatory = ModelObservatory(
+        nside=nside,
         mjd=mjd_now,
         mjd_start=survey_start,
         kinem_model=kinematic_model,  # Modified kinematics

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -312,16 +312,13 @@ class Conditions:
         self.tel_az = None
         self.cumulative_azimuth_rad = None
 
-        # Telescope limits - these can be None
+        # Sky coverage limits.
         # These should be in radians.
         self.sky_az_limits = None
         self.sky_alt_limits = None
-        # Kinematic model (real slew) limits - these can't be None
-        # if you are using the AltAzShadowMaskBasisFunction.
-        # Setting default values here that will not restrict any choices,
-        # but just avoiding "None".  Values in Radians.
-        self.tel_alt_limits = [np.radians(-10), np.radians(100)]
-        self.tel_az_limits = [np.radians(-270), np.radians(270)]
+        # Kinematic model (real slew) limits.
+        self.tel_alt_limits = None
+        self.tel_az_limits = None
 
         # Full sky cloud map
         self._cloud_map = None

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -176,15 +176,19 @@ class Conditions:
         scheduled_observations : `np.ndarray`, (M,)
             A list of MJD times when there are scheduled observations.
             Defaults to empty array.
-        tel_az_limits : `list` [[`float`, `float`]]
+        sky_az_limits : `list` [[`float`, `float`]]
             A list of lists giving valid azimuth ranges. e.g.,
             [0, 2*np.pi] would mean all azimuth values are valid, while
             [[0, np.pi/2], [3*np.pi/2, 2*np.pi]] would mean anywhere in
             the south is invalid.  Radians.
-        tel_alt_limits : `list` [[`float`, `float`]]
+        sky_alt_limits : `list` [[`float`, `float`]]
             A list of lists giving valid altitude ranges. Radians.
-        altaz_limit_pad : `float`
-            Pad to surround the tel_az_limits and tel_alt_limits with.
+        tel_az_limits : `list` [`float`, `float`]
+            A simple two-element list giving the valid azimuth ranges
+            for the telescope movement. Radians.
+        tel_alt_limits : `list` [`float`, `float`]
+            A simple two-element list giving the valid altitude ranges
+            for the telescope movement. Radians
 
         Attributes (calculated on demand and cached)
         ------------------------------------------
@@ -310,17 +314,14 @@ class Conditions:
 
         # Telescope limits - these can be None
         # These should be in radians.
-        self.tel_az_limits = None
-        self.tel_alt_limits = None
+        self.sky_az_limits = None
+        self.sky_alt_limits = None
         # Kinematic model (real slew) limits - these can't be None
         # if you are using the AltAzShadowMaskBasisFunction.
-        # These generous limits won't restrict the AltAzShadowMask.
-        # Radians.
-        self.kinematic_alt_limits = [np.radians(-10), np.radians(100)]
-        self.kinematic_az_limits = [np.radians(-250), np.radians(250)]
-        # This has a (reasonable) default value, to avoid failure of
-        # AltAzShadowMask in case this isn't set otherwise.
-        self.altaz_limit_pad = np.radians(2)
+        # Setting default values here that will not restrict any choices,
+        # but just avoiding "None".  Values in Radians.
+        self.tel_alt_limits = [np.radians(-10), np.radians(100)]
+        self.tel_az_limits = [np.radians(-270), np.radians(270)]
 
         # Full sky cloud map
         self._cloud_map = None

--- a/rubin_scheduler/scheduler/features/features.py
+++ b/rubin_scheduler/scheduler/features/features.py
@@ -277,12 +277,6 @@ class NObservations(BaseSurveyFeature):
             self.scheduler_note = survey_name
         else:
             self.scheduler_note = scheduler_note
-        # This feature is not used with "scheduler_note" in the baseline
-        # survey. Should it really match scheduler_notes which contain
-        # self.scheduler_note or should it be vice versa?
-        # (i.e. this works as: self.scheduler_note = "survey" matches only
-        # scheduler_note == "survey", but self.scheduler_note = "survey a"
-        # will match both "survey" and "survey a".
         self.bins = np.arange(hp.nside2npix(nside) + 1) - 0.5
 
     def add_observations_array(self, observations_array, observations_hpid):

--- a/rubin_scheduler/scheduler/features/features.py
+++ b/rubin_scheduler/scheduler/features/features.py
@@ -214,9 +214,11 @@ class LastObservation(BaseSurveyFeature):
     Parameters
     ----------
     scheduler_note : `str` or None, optional
-        Value of the scheduler_note to match, if not None.
+        The scheduler_note to match.
+        Scheduler_note values which match this OR which contain this value
+        as a subset of their string will match.
     survey_name : `str` or None, optional
-        Backwards compatible version of scheduler_note. Deprecated.
+        Backwards compatible shim for scheduler_note. Deprecated.
     """
 
     def __init__(self, scheduler_note=None, survey_name=None):
@@ -232,7 +234,7 @@ class LastObservation(BaseSurveyFeature):
             valid_indx = np.ones(observations_array.size, dtype=bool)
             tmp = [self.scheduler_note in name for name in observations_array["scheduler_note"]]
             valid_indx = valid_indx * np.array(tmp)
-            if len(tmp) > 0:
+            if valid_indx.sum() > 0:
                 self.feature = observations_array[valid_indx][-1]
         else:
             if len(observations_array) > 0:

--- a/rubin_scheduler/scheduler/features/features.py
+++ b/rubin_scheduler/scheduler/features/features.py
@@ -14,6 +14,7 @@ __all__ = (
 )
 
 import warnings
+from abc import ABC, abstractmethod
 
 import healpy as hp
 import numpy as np
@@ -35,7 +36,7 @@ def send_unused_deprecation_warning(name):
     warnings.warn(message, FutureWarning)
 
 
-class BaseFeature:
+class BaseFeature(ABC):
     """The base class for features.
     This defines the standard API: a Feature should include
     a `self.feature` attribute, which could be a float, bool,
@@ -63,6 +64,7 @@ class BaseSurveyFeature(BaseFeature):
     `add_observation_array`.
     """
 
+    @abstractmethod
     def add_observations_array(self, observations_array, observations_hpid):
         """Update self.feature based on information in `observations_array`
         and `observations_hpid`.
@@ -86,6 +88,7 @@ class BaseSurveyFeature(BaseFeature):
         print(self)
         raise NotImplementedError
 
+    @abstractmethod
     def add_observation(self, observation, indx=None, **kwargs):
         """Update self.feature based on information in `observation`.
         Observations should be ordered in monotonically increasing time.

--- a/rubin_scheduler/scheduler/features/features.py
+++ b/rubin_scheduler/scheduler/features/features.py
@@ -313,7 +313,17 @@ class LargestN:
 
 
 class LastNObsTimes(BaseSurveyFeature):
-    """Record the last three observations for each healpixel"""
+    """Record the last three observations for each healpixel.
+
+    Parameters
+    ----------
+    filtername : `str` or None
+        Match visits in this filtername.
+    n_obs : `int`
+        The number of prior observations to track.
+    nside : `int`
+        The nside of the healpix map.
+    """
 
     def __init__(self, filtername=None, n_obs=3, nside=DEFAULT_NSIDE):
         self.filtername = filtername
@@ -563,6 +573,8 @@ class LastObserved(BaseSurveyFeature):
     """
     Track the MJD when a pixel was last observed.
     Assumes observations are added in chronological order.
+
+    Calculated per healpix.
 
     Parameters
     ----------

--- a/rubin_scheduler/scheduler/features/features.py
+++ b/rubin_scheduler/scheduler/features/features.py
@@ -154,49 +154,55 @@ class NObsCount(BaseSurveyFeature):
 
     Parameters
     ----------
-    note : `str` or None
+    scheduler_note : `str` or None
         Count observations that match `str` in their scheduler_note field.
         Note can be a substring of scheduler_note, and will still match.
     filtername : `str` or None
         Optionally also (or independently) specify a filter to match.
+    note : `str` or None
+        Backwards compatible shim for scheduler_note.
     """
 
-    def __init__(self, note=None, filtername=None):
+    def __init__(self, scheduler_note=None, filtername=None, note=None):
         self.feature = 0
-        self.note = note
-        if self.note == "":
-            self.note = None
+        if scheduler_note is None:
+            self.scheduler_note = note
+        else:
+            self.scheduler_note = scheduler_note
+        # In case scheduler_note got set with empty string, replace with None
+        if self.scheduler_note == "":
+            self.scheduler_note = None
         self.filtername = filtername
 
     def add_observations_array(self, observations_array, observations_hpid):
-        if self.note is None and self.filtername is None:
+        if self.scheduler_note is None and self.filtername is None:
             self.feature += observations_array.size
-        elif self.note is None and self.filtername is not None:
+        elif self.scheduler_note is None and self.filtername is not None:
             in_filt = np.where(observations_array["filter"] == self.filtername)
             self.feature += np.size(in_filt)
-        elif self.note is not None and self.filtername is None:
-            count = [self.note in note for note in observations_array["scheduler_note"]]
+        elif self.scheduler_note is not None and self.filtername is None:
+            count = [self.scheduler_note in note for note in observations_array["scheduler_note"]]
             self.feature += np.sum(count)
         else:
             # note and filtername are defined
             in_filt = np.where(observations_array["filter"] == self.filtername)
-            count = [self.note in note for note in observations_array["scheduler_note"][in_filt]]
+            count = [self.scheduler_note in note for note in observations_array["scheduler_note"][in_filt]]
             self.feature += np.sum(count)
 
     def add_observation(self, observation, indx=None):
         # Track all observations
-        if self.note is None and self.filtername is None:
+        if self.scheduler_note is None and self.filtername is None:
             self.feature += 1
-        elif self.note is None and self.filtername is not None:
+        elif self.scheduler_note is None and self.filtername is not None:
             if observation["filter"][0] in self.filtername:
                 self.feature += 1
-        elif self.note is not None and self.filtername is None:
-            if self.note in observation["scheduler_note"][0]:
+        elif self.scheduler_note is not None and self.filtername is None:
+            if self.scheduler_note in observation["scheduler_note"][0]:
                 self.feature += 1
         else:
-            if (observation["filter"][0] in self.filtername) and self.note in observation["scheduler_note"][
-                0
-            ]:
+            if (observation["filter"][0] in self.filtername) and self.scheduler_note in observation[
+                "scheduler_note"
+            ][0]:
                 self.feature += 1
 
 

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -127,12 +127,12 @@ class ModelObservatory:
         to the next night. Default "sun_n12_rising", e.g., sun at
         -12 degrees and rising. Other options are "sun_n18_rising"
         and "sunrise".
-    tel_az_limits : `list` [[`float`, `float`]]
+    sky_az_limits : `list` [[`float`, `float`]]
         A list of lists giving valid azimuth ranges. e.g.,
         [0, 180] would mean all azimuth values are valid, while
         [[0, 90], [270, 360]] or [270, 90] would mean anywhere in
         the south is invalid.  Degrees.
-    tel_alt_limits : `list` [[`float`, `float`]]
+    sky_alt_limits : `list` [[`float`, `float`]]
         A list of lists giving valid altitude ranges. Degrees.
         For both the alt and az limits, if a particular alt (or az)
         value is included in any limit, it is valid for all of them.
@@ -165,8 +165,8 @@ class ModelObservatory:
         wind_data=None,
         starting_time_key="sun_n12_setting",
         ending_time_key="sun_n12_rising",
-        tel_alt_limits=None,
-        tel_az_limits=None,
+        sky_alt_limits=None,
+        sky_az_limits=None,
         telescope="rubin",
     ):
         self.nside = nside
@@ -296,25 +296,25 @@ class ModelObservatory:
             self.observatory = kinem_model
 
         # Pick up tel alt and az limits from kwargs
-        if tel_alt_limits is not None:
-            self.tel_alt_limits = np.radians(tel_alt_limits)
+        if sky_alt_limits is not None:
+            self.sky_alt_limits = np.radians(sky_alt_limits)
         else:
-            self.tel_alt_limits = None
-        if tel_az_limits is not None:
-            self.tel_az_limits = np.radians(tel_az_limits)
+            self.sky_alt_limits = None
+        if sky_az_limits is not None:
+            self.sky_az_limits = np.radians(sky_az_limits)
         else:
-            self.tel_az_limits = None
+            self.sky_az_limits = None
         # Add the observatory alt/az limits to the user-defined limits
         # But we do have to be careful that we're not overriding more
         # restrictive limits that were already set.
         # So we'll just keep these separate.
-        self.kinematic_tel_alt_limits = copy.deepcopy(
+        self.tel_alt_limits = copy.deepcopy(
             [
                 self.observatory.telalt_minpos_rad,
                 self.observatory.telalt_maxpos_rad,
             ]
         )
-        self.kinematic_tel_az_limits = copy.deepcopy(
+        self.tel_az_limits = copy.deepcopy(
             [self.observatory.telaz_minpos_rad, self.observatory.telaz_maxpos_rad]
         )
         # Each of these limits will be treated as hard limits that we don't
@@ -467,11 +467,10 @@ class ModelObservatory:
         self.conditions.mjd_start = self.mjd_start
 
         # Telescope limits
-        self.conditions.tel_az_limits = self.tel_az_limits
+        self.conditions.sky_az_limits = self.sky_az_limits
+        self.conditions.sky_alt_limits = self.sky_alt_limits
         self.conditions.tel_alt_limits = self.tel_alt_limits
-        self.conditions.kinematic_alt_limits = self.kinematic_tel_alt_limits
-        self.conditions.kinematic_az_limits = self.kinematic_tel_az_limits
-        self.conditions.altaz_limit_pad = self.altaz_limit_pad
+        self.conditions.tel_az_limits = self.tel_az_limits
 
         # Planet positions from almanac
         self.conditions.planet_positions = self.almanac.get_planet_positions(self.mjd)

--- a/rubin_scheduler/scheduler/surveys/base_survey.py
+++ b/rubin_scheduler/scheduler/surveys/base_survey.py
@@ -108,7 +108,9 @@ class BaseSurvey:
         if detailers is None:
             self.detailers = [ZeroRotDetailer(nside=nside)]
         else:
-            self.detailers = detailers
+            # If there are detailers -- copy them, because we're
+            # about to change the list (and users can be reusing this list).
+            self.detailers = deepcopy(detailers)
 
         # Scheduled observations
         self.scheduled_obs = scheduled_obs

--- a/rubin_scheduler/scheduler/surveys/field_survey.py
+++ b/rubin_scheduler/scheduler/surveys/field_survey.py
@@ -184,8 +184,8 @@ class FieldSurvey(BaseSurvey):
         # recorded - both for any note and for this note.
         self.extra_features["ObsRecorded"] = NObsCount(scheduler_note=None)
         self.extra_features["LastObs"] = LastObservation(scheduler_note=None)
-        self.extra_features["ObsRecorded_match"] = NObsCount(scheduler_note=self.scheduler_note)
-        self.extra_features["LastObs_match"] = LastObservation(scheduler_note=self.scheduler_note)
+        self.extra_features["ObsRecorded_note"] = NObsCount(scheduler_note=self.scheduler_note)
+        self.extra_features["LastObs_note"] = LastObservation(scheduler_note=self.scheduler_note)
 
     def _generate_survey_name(self, target_name=None):
         if target_name is not None:

--- a/rubin_scheduler/scheduler/surveys/field_survey.py
+++ b/rubin_scheduler/scheduler/surveys/field_survey.py
@@ -113,6 +113,11 @@ class FieldSurvey(BaseSurvey):
             science_program=science_program,
             observation_reason=observation_reason,
         )
+        # It's useful to save these as class attributes too
+        self.target_name = target_name
+        self.science_program = science_program
+        self.observation_reason = observation_reason
+
         self.indx = ra_dec2_hpid(self.nside, self.ra_deg, self.dec_deg)
 
         # Set all basis function equal.
@@ -145,7 +150,9 @@ class FieldSurvey(BaseSurvey):
             if isinstance(nexps, (float, int)):
                 nexps = dict([(filtername, nexps) for filtername in sequence])
 
-        if isinstance(sequence, str):
+        if isinstance(sequence, ObservationArray) | isinstance(sequence[0], ObservationArray):
+            self.observations = sequence
+        else:
             self.observations = []
             for filtername in sequence:
                 for j in range(nvisits[filtername]):
@@ -157,8 +164,6 @@ class FieldSurvey(BaseSurvey):
                     obs["nexp"] = nexps[filtername]
                     obs["scheduler_note"] = self.scheduler_note
                     self.observations.append(obs)
-        else:
-            self.observations = sequence
 
         # Let's just make this an array for ease of use
         self.observations = np.concatenate(self.observations)

--- a/rubin_scheduler/scheduler/surveys/field_survey.py
+++ b/rubin_scheduler/scheduler/surveys/field_survey.py
@@ -1,7 +1,6 @@
 __all__ = ("FieldSurvey",)
 
 import copy
-import warnings
 from functools import cached_property
 
 import numpy as np
@@ -32,11 +31,11 @@ class FieldSurvey(BaseSurvey):
         Dictionary of the number of visits in each filter.
         Default of None will use a backup sequence of 20 visits per filter.
         Must contain all filters in sequence.
-    exptime : `dict` {`str`: `float`}
+    exptimes : `dict` {`str`: `float`}
         Dictionary of the exposure time for visits in each filter.
         Default of None will use a backup sequence of 38s in u, and
         29.2s in all other bands. Must contain all filters in sequence.
-    nexp : dict` {`str`: `int`}
+    nexps : dict` {`str`: `int`}
         Dictionary of the number of exposures per visit in each filter.
         Default of None will use a backup sequence of 1 exposure per visit
         in u band, 2 in all other bands. Must contain all filters in sequence.
@@ -70,8 +69,6 @@ class FieldSurvey(BaseSurvey):
     flush_pad : `float`
         How long to hold observations in the queue after they
         were expected to be completed (minutes).
-    reward_value : `float`
-        An unused kwarg, provided for backward compatibility.
     """
 
     def __init__(
@@ -95,25 +92,10 @@ class FieldSurvey(BaseSurvey):
         nside=DEFAULT_NSIDE,
         flush_pad=30.0,
         detailers=None,
-        reward_value=None,
-        nexp=None,
     ):
         default_nvisits = {"u": 20, "g": 20, "r": 20, "i": 20, "z": 20, "y": 20}
         default_exptimes = {"u": 38, "g": 29.2, "r": 29.2, "i": 29.2, "z": 29.2, "y": 29.2}
         default_nexps = {"u": 1, "g": 2, "r": 2, "i": 2, "z": 2, "y": 2}
-
-        # Deprecated kwarg messages
-        if reward_value is not None:
-            warnings.warn("reward_value has been unused and will be deprecated.")
-        if nexp is not None:
-            if nexps is not None:
-                warnings.warn(
-                    "Use one of `nexp` or `nexps`: `nexps` will be "
-                    "supported going forward and will override."
-                )
-            if nexps is None:
-                warnings.warn("Please use `nexps` in the future. " "Will adapt from `nexp` presently.")
-                nexps = nexp
 
         self.ra = np.radians(RA)
         self.ra_hours = RA / 360.0 * 24.0

--- a/rubin_scheduler/scheduler/surveys/scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/scripted_surveys.py
@@ -215,22 +215,22 @@ class ScriptedSurvey(BaseSurvey):
 
         # Also check the alt,az limits given by the conditions object
         count = in_range * 0
-        if conditions.tel_alt_limits is not None:
-            for limits in conditions.tel_alt_limits:
+        if conditions.sky_alt_limits is not None:
+            for limits in conditions.sky_alt_limits:
                 ir = np.where((alt[in_range] >= np.min(limits)) & (alt[in_range] <= np.max(limits)))[0]
                 count[ir] += 1
             good = np.where(count > 0)[0]
             in_range = in_range[good]
         # Check against kinematic limits too
         ir = np.where(
-            (alt[in_range] >= np.min(conditions.kinematic_alt_limits))
-            & (alt[in_range] <= np.max(conditions.kinematic_alt_limits))
+            (alt[in_range] >= np.min(conditions.tel_alt_limits))
+            & (alt[in_range] <= np.max(conditions.tel_alt_limits))
         )[0]
         in_range = in_range[ir]
 
         count = in_range * 0
-        if conditions.tel_az_limits is not None:
-            for limits in conditions.tel_az_limits:
+        if conditions.sky_az_limits is not None:
+            for limits in conditions.sky_az_limits:
                 az_min = limits[0]
                 az_max = limits[1]
                 if np.abs(az_max - az_min) >= (2 * np.pi):
@@ -241,9 +241,9 @@ class ScriptedSurvey(BaseSurvey):
                     count[ir] += 1
             good = np.where(count > 0)[0]
             in_range = in_range[good]
-        if np.abs(conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) < (2 * np.pi):
-            az_range = (conditions.kinematic_az_limits[1] - conditions.kinematic_az_limits[0]) % (2 * np.pi)
-            ir = np.where((az[in_range] - conditions.kinematic_az_limits[0]) % (2 * np.pi) <= az_range)[0]
+        if np.abs(conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) < (2 * np.pi):
+            az_range = (conditions.tel_az_limits[1] - conditions.tel_az_limits[0]) % (2 * np.pi)
+            ir = np.where((az[in_range] - conditions.tel_az_limits[0]) % (2 * np.pi) <= az_range)[0]
             in_range = in_range[ir]
 
         # Check that filter needed is mounted

--- a/rubin_scheduler/scheduler/utils/sky_area.py
+++ b/rubin_scheduler/scheduler/utils/sky_area.py
@@ -81,7 +81,7 @@ def generate_all_sky(nside=DEFAULT_NSIDE, elevation_limit=20, mask=hp.UNSEEN):
 
     # Calculate coordinates of everything.
     skymap = np.zeros(hp.nside2npix(nside), float)
-    ra, dec = _hpid2_ra_dec(nside, np.arange(hp.nside2npix(nside)))(nside=nside)
+    ra, dec = _hpid2_ra_dec(nside, np.arange(hp.nside2npix(nside)))
     coord = SkyCoord(ra=ra * u.rad, dec=dec * u.rad, frame="icrs")
     eclip_lat = coord.barycentrictrueecliptic.lat.deg
     eclip_lon = coord.barycentrictrueecliptic.lon.deg

--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -13,8 +13,6 @@ __all__ = (
     "warm_start",
     "ObservationArray",
     "ScheduledObservationArray",
-    "empty_observation",
-    "scheduled_observation",
     "gnomonic_project_toxy",
     "gnomonic_project_tosky",
     "raster_sort",
@@ -674,21 +672,6 @@ class ObservationArray(np.ndarray):
         ]
         obj = np.zeros(n, dtype=dtypes).view(cls)
         return obj
-
-
-def empty_observation(n=1):
-    """For backwards compatibility"""
-    warnings.warn("Function empty_observation is deprecated, use ObservationArray", FutureWarning)
-    result = ObservationArray(n=n)
-    return result
-
-
-def scheduled_observation(n=1):
-    warnings.warn(
-        "Function scheduled_observation is deprecated, use ScheduledObservationArray", FutureWarning
-    )
-    result = ScheduledObservationArray(n=n)
-    return result
 
 
 class ScheduledObservationArray(np.ndarray):

--- a/tests/scheduler/test_basisfuncs.py
+++ b/tests/scheduler/test_basisfuncs.py
@@ -203,9 +203,8 @@ class TestBasis(unittest.TestCase):
         nside = 32
         conditions = Conditions(nside=nside)
         conditions.mjd = 59000.0
-        conditions.altaz_limit_pad = np.radians(2.0)
-        conditions.kinematic_az_limits = [np.radians(-250), np.radians(250)]
-        conditions.kinematic_alt_limits = [np.radians(-100), np.radians(100)]
+        conditions.tel_az_limits = [np.radians(-250), np.radians(250)]
+        conditions.tel_alt_limits = [np.radians(-100), np.radians(100)]
         # With no (real) limits, including no limits in conditions
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=0, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
@@ -238,7 +237,7 @@ class TestBasis(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result[~good])))
         self.assertTrue(np.all(result[good] == 0))
         # And set altitude limits from the conditions
-        conditions.tel_alt_limits = [[np.radians(40), np.radians(60)]]
+        conditions.sky_alt_limits = [[np.radians(40), np.radians(60)]]
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=0, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
         )
@@ -247,7 +246,7 @@ class TestBasis(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result[~good])))
         self.assertTrue(np.all(result[good] == 0))
         # Set multiple altitude limits from the conditions
-        conditions.tel_alt_limits = [[np.radians(40), np.radians(60)], [np.radians(80), np.radians(90)]]
+        conditions.sky_alt_limits = [[np.radians(40), np.radians(60)], [np.radians(80), np.radians(90)]]
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
         )
@@ -262,8 +261,8 @@ class TestBasis(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result[~good])))
         self.assertTrue(np.all(result[good] == 0))
         # Set azimuth limits
-        conditions.tel_alt_limits = None
-        conditions.tel_az_limits = [[np.radians(270), np.radians(90)]]
+        conditions.sky_alt_limits = None
+        conditions.sky_az_limits = [[np.radians(270), np.radians(90)]]
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
         )
@@ -277,8 +276,8 @@ class TestBasis(unittest.TestCase):
         )
         self.assertTrue(np.all(np.isnan(result[~good])))
         # Set azimuth limits, direction sensitive
-        conditions.tel_alt_limits = None
-        conditions.tel_az_limits = [[np.radians(90), np.radians(270)]]
+        conditions.sky_alt_limits = None
+        conditions.sky_az_limits = [[np.radians(90), np.radians(270)]]
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
         )
@@ -292,9 +291,9 @@ class TestBasis(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result[~good])))
         self.assertTrue(np.all(result[good] == 0))
         # Set altitude limits from kinematic model
-        conditions.tel_alt_limits = None
-        conditions.kinematic_alt_limits = [np.radians(20), np.radians(86.5)]
-        conditions.tel_az_limits = None
+        conditions.sky_alt_limits = None
+        conditions.tel_alt_limits = [np.radians(20), np.radians(86.5)]
+        conditions.sky_az_limits = None
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
         )
@@ -308,10 +307,10 @@ class TestBasis(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result[~good])))
         self.assertTrue(np.all(result[good] == 0))
         # Set azimuth limits from kinematic model
-        conditions.tel_alt_limits = None
-        conditions.tel_az_limits = None
-        conditions.kinematic_az_limits = [np.radians(90), np.radians(270)]
-        conditions.kinematic_alt_limits = [np.radians(-100), np.radians(100)]
+        conditions.sky_alt_limits = None
+        conditions.sky_az_limits = None
+        conditions.tel_az_limits = [np.radians(90), np.radians(270)]
+        conditions.tel_alt_limits = [np.radians(-100), np.radians(100)]
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=-90, max_alt=90, min_az=0, max_az=360, shadow_minutes=0
         )
@@ -326,10 +325,10 @@ class TestBasis(unittest.TestCase):
         self.assertTrue(np.all(result[good] == 0))
         # Check very simple shadow minutes
         # Set azimuth limits from kinematic model
-        conditions.tel_alt_limits = None
-        conditions.tel_az_limits = None
-        conditions.kinematic_az_limits = [np.radians(-250), np.radians(250)]
-        conditions.kinematic_alt_limits = [np.radians(-100), np.radians(100)]
+        conditions.sky_alt_limits = None
+        conditions.sky_az_limits = None
+        conditions.tel_az_limits = [np.radians(-250), np.radians(250)]
+        conditions.tel_alt_limits = [np.radians(-100), np.radians(100)]
         bf = basis_functions.AltAzShadowMaskBasisFunction(
             nside=nside, min_alt=20, max_alt=85, min_az=0, max_az=360, shadow_minutes=0
         )

--- a/tests/scheduler/test_features.py
+++ b/tests/scheduler/test_features.py
@@ -141,6 +141,7 @@ class TestFeatures(unittest.TestCase):
         note_last_observed.add_observation(observation=observation)
 
         assert note_last_observed.feature is None
+        note_last_observed.add_observations_array(observations_array, observations_hpid)
 
         observation["scheduler_note"] = "foo"
 

--- a/tests/scheduler/test_features.py
+++ b/tests/scheduler/test_features.py
@@ -372,48 +372,53 @@ class TestFeatures(unittest.TestCase):
             observations_list[i]["filter"] = "g"
         observations_array, observations_hpid_array = make_observations_arrays(observations_list)
         # Count the observations matching any note
-        count_feature = features.NObsCount(note=None, filtername=None)
+        count_feature = features.NObsCount(scheduler_note=None, filtername=None)
         for obs in observations_list:
             count_feature.add_observation(obs)
         self.assertTrue(count_feature.feature == 5)
         # and count again using add_observations_array
-        count_feature = features.NObsCount(note=None)
+        count_feature = features.NObsCount(scheduler_note=None)
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature == 5)
         # Count using a note to match
         # Count the observations matching specific note
-        count_feature = features.NObsCount(note="survey a")
+        count_feature = features.NObsCount(scheduler_note="survey a")
         for obs in observations_list:
             count_feature.add_observation(obs)
         self.assertTrue(count_feature.feature == 2)
         # and count again using add_observations_array
-        count_feature = features.NObsCount(note="survey a")
+        count_feature = features.NObsCount(scheduler_note="survey a")
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature == 2)
         # Count the observations matching subset of note
-        count_feature = features.NObsCount(note="survey")
+        count_feature = features.NObsCount(scheduler_note="survey")
         for obs in observations_list:
             count_feature.add_observation(obs)
         self.assertTrue(count_feature.feature == 5)
         # and count again using add_observations_array
-        count_feature = features.NObsCount(note="survey")
+        count_feature = features.NObsCount(scheduler_note="survey")
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature == 5)
         # Count the observations matching filter
-        count_feature = features.NObsCount(note=None, filtername="r")
+        count_feature = features.NObsCount(scheduler_note=None, filtername="r")
         for obs in observations_list:
             count_feature.add_observation(obs)
         self.assertTrue(count_feature.feature == 2)
         # and count again using add_observations_array
-        count_feature = features.NObsCount(note=None, filtername="r")
+        count_feature = features.NObsCount(scheduler_note=None, filtername="r")
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature == 2)
         # Count the observations matching filter and surveyname
-        count_feature = features.NObsCount(note="survey b", filtername="r")
+        count_feature = features.NObsCount(scheduler_note="survey b", filtername="r")
         for obs in observations_list:
             count_feature.add_observation(obs)
         self.assertTrue(count_feature.feature == 1)
         # and count again using add_observations_array
+        count_feature = features.NObsCount(scheduler_note="survey b", filtername="r")
+        count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
+        self.assertTrue(count_feature.feature == 1)
+
+        # Test backward compatibilty shim
         count_feature = features.NObsCount(note="survey b", filtername="r")
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature == 1)
@@ -440,10 +445,10 @@ class TestFeatures(unittest.TestCase):
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature["mjd"] == observations_list[-1]["mjd"])
         # Observations matching a specific note.
-        count_feature = features.LastObservation(scheduler_note="survey a")
+        count_feature = features.LastObservation(scheduler_note="survey b")
         for obs in observations_list:
             count_feature.add_observation(obs)
-        self.assertTrue(count_feature.feature["mjd"] == observations_list[-2]["mjd"])
+        self.assertTrue(count_feature.feature["mjd"] == observations_list[-1]["mjd"])
         # and count again using add_observations_array
         count_feature = features.LastObservation(scheduler_note="survey a")
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)

--- a/tests/scheduler/test_features.py
+++ b/tests/scheduler/test_features.py
@@ -53,10 +53,51 @@ def make_observations_arrays(observations_list, nside=32):
     # between index in observations_array and index in hpid
     observations_hpids_array[list(observations_array.dtype.names)] = observations_array[big_array_indx]
     observations_hpids_array[hpids.dtype.names[0]] = hpids
-    return observations_array, observations_hpids_array
+    return observations_array, observations_hpids_array, list_of_hpids
 
 
 class TestFeatures(unittest.TestCase):
+
+    def test_features_add_observation_methods(self):
+        # Generic test that add_observations_array equals add_observations
+        # Under the default conditions.
+        # Tests for each feature should still check on non-default kwargs
+        observations_list = make_observations_list(20)
+        for i, obs in enumerate(observations_list):
+            if i % 2 == 0:
+                observations_list[i]["dec"] = np.radians(-10)
+            if i % 3 == 0:
+                observations_list[i]["scheduler_note"] = "a"
+            if (i - 1) % 3 == 0:
+                observations_list[i]["scheduler_note"] = "b"
+            if i > 10:
+                observations_list[i]["filter"] = "g"
+        observations_array, observations_hpid, list_of_hpids = make_observations_arrays(observations_list)
+        features_to_test = features.BaseSurveyFeature.__subclasses__()
+        for ff in features_to_test:
+            test_featureA = ff()
+            for obs, indx in zip(observations_list, list_of_hpids):
+                test_featureA.add_observation(obs, indx=indx)
+            test_featureB = ff()
+            test_featureB.add_observations_array(observations_array, observations_hpid)
+            print(test_featureA.__class__.__name__)
+            if isinstance(test_featureA.feature, (float, int)):
+                self.assertTrue(test_featureA.feature == test_featureB.feature)
+            elif isinstance(test_featureA.feature, ObservationArray):
+                self.assertTrue(test_featureA.feature == test_featureB.feature)
+            else:
+                # Test nans (if present) are in the same places
+                nanA = np.where(np.isnan(test_featureA.feature), 1, 0)
+                nanB = np.where(np.isnan(test_featureB.feature), 1, 0)
+                self.assertTrue(np.all(nanA == nanB))
+                # Test equal where not nan
+                self.assertTrue(
+                    np.all(
+                        test_featureA.feature[np.where(nanA == 0)]
+                        == test_featureB.feature[np.where(nanA == 0)]
+                    )
+                )
+
     def test_pair_in_night(self):
         pin = features.PairInNight(gap_min=25.0, gap_max=45.0)
         self.assertEqual(np.max(pin.feature), 0.0)
@@ -140,7 +181,7 @@ class TestFeatures(unittest.TestCase):
                 obs["scheduler_note"] = "test 2"
             if i > 3:
                 obs["filter"] = "g"
-        observations_array, observations_hpid = make_observations_arrays(observations_list)
+        observations_array, observations_hpid, list_of_hpids = make_observations_arrays(observations_list)
 
         # Test with no note - match all
         note_last_observed = features.LastObservationMjd(scheduler_note=None)
@@ -148,6 +189,7 @@ class TestFeatures(unittest.TestCase):
             note_last_observed.add_observation(observation=obs)
         self.assertTrue(note_last_observed.feature == observations_list[-1]["mjd"])
 
+        note_last_observed = features.LastObservationMjd(scheduler_note=None)
         note_last_observed.add_observations_array(observations_array, observations_hpid)
         self.assertTrue(note_last_observed.feature == observations_list[-1]["mjd"])
 
@@ -157,6 +199,7 @@ class TestFeatures(unittest.TestCase):
             note_last_observed.add_observation(observation=obs)
         self.assertTrue(note_last_observed.feature is None)
 
+        note_last_observed = features.LastObservationMjd(scheduler_note="special")
         note_last_observed.add_observations_array(observations_array, observations_hpid)
         self.assertTrue(note_last_observed.feature is None)
 
@@ -166,6 +209,7 @@ class TestFeatures(unittest.TestCase):
             note_last_observed.add_observation(observation=obs)
         self.assertTrue(note_last_observed.feature == observations_list[-1]["mjd"])
 
+        note_last_observed = features.LastObservationMjd(scheduler_note="test")
         note_last_observed.add_observations_array(observations_array, observations_hpid)
         self.assertTrue(note_last_observed.feature == observations_list[-1]["mjd"])
 
@@ -178,6 +222,10 @@ class TestFeatures(unittest.TestCase):
             note_last_observed.add_observation(observation=obs)
         self.assertTrue(note_last_observed.feature == observations_list[-1]["mjd"])
 
+        note_last_observed = features.LastObservationMjd(
+            note="test",
+            filtername="g",
+        )
         note_last_observed.add_observations_array(observations_array, observations_hpid)
         self.assertTrue(note_last_observed.feature == observations_list[-1]["mjd"])
 
@@ -190,6 +238,10 @@ class TestFeatures(unittest.TestCase):
             note_last_observed.add_observation(observation=obs)
         self.assertTrue(note_last_observed.feature == observations_list[3]["mjd"])
 
+        note_last_observed = features.LastObservationMjd(
+            note="test",
+            filtername="r",
+        )
         note_last_observed.add_observations_array(observations_array, observations_hpid)
         self.assertTrue(note_last_observed.feature == observations_list[3]["mjd"])
 
@@ -282,36 +334,12 @@ class TestFeatures(unittest.TestCase):
 
         # Set up to check add_observations_array - use observations from above.
         observations[0]["mjd"] = mjd_start
-        observations_array = np.empty(len(observations), dtype=observations[0].dtype)
-        for i, obs in enumerate(observations):
-            observations_array[i] = obs
-        # Build observations_hpids_array.
-        # Find list of lists of healpixels
-        # (should match [indxs, indxs, indxs2] from above)
-        list_of_hpids = pointing2indx(observations_array["RA"], observations_array["dec"])
+        observations_array, observations_hpids_array, list_of_hpids = make_observations_arrays(
+            observations, nside=64
+        )
         indxs_list = [indxs, indxs, indxs2]
         for hi, ii in zip(list_of_hpids, indxs_list):
             self.assertTrue(set(hi) == set(ii))
-        # Unravel list-of-lists (list_of_hpids) to match against observations
-        hpids = []
-        big_array_indx = []
-        for i, indxs in enumerate(list_of_hpids):
-            for indx in indxs:
-                hpids.append(indx)
-                big_array_indx.append(i)
-        hpids = np.array(hpids, dtype=[("hpid", int)])
-        # Set up format / dtype for observations_hpids_array
-        names = list(observations_array.dtype.names)
-        types = [observations_array[name].dtype for name in names]
-        names.append(hpids.dtype.names[0])
-        types.append(hpids["hpid"].dtype)
-        ndt = list(zip(names, types))
-        observations_hpids_array = np.empty(hpids.size, dtype=ndt)
-        # Populate observations_hpid_array - big_array_indx points
-        # between index in observations_array and index in hpid
-        observations_hpids_array[list(observations_array.dtype.names)] = observations_array[big_array_indx]
-        observations_hpids_array[hpids.dtype.names[0]] = hpids
-        # Now check that adding observations to feature via
         # add_observations_array results in the same feature
         feature_obs = features.NObservationsCurrentSeason(nside=nside, mjd_start=mjd_start)
         for obs, idx in zip(observations, indxs_list):
@@ -381,14 +409,16 @@ class TestFeatures(unittest.TestCase):
             observations_list[i]["filter"] = "r"
         for i in [2, 3, 4]:
             observations_list[i]["filter"] = "g"
-        observations_array, observations_hpid_array = make_observations_arrays(observations_list)
+        observations_array, observations_hpid_array, list_of_hpids = make_observations_arrays(
+            observations_list
+        )
         # Count the observations matching any note
         count_feature = features.NObsCount(scheduler_note=None, filtername=None)
         for obs in observations_list:
             count_feature.add_observation(obs)
         self.assertTrue(count_feature.feature == 5)
         # and count again using add_observations_array
-        count_feature = features.NObsCount(scheduler_note=None)
+        count_feature = features.NObsCount(scheduler_note=None, filtername=None)
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature == 5)
         # Count using a note to match
@@ -445,11 +475,13 @@ class TestFeatures(unittest.TestCase):
         observations_list[1]["scheduler_note"] = "survey"
         observations_list[2]["scheduler_note"] = "survey a"
         observations_list[3]["scheduler_note"] = "survey b"
-        observations_array, observations_hpid_array = make_observations_arrays(observations_list)
+        observations_array, observations_hpid_array, list_of_hpids = make_observations_arrays(
+            observations_list
+        )
         # Observations matching any note
         count_feature = features.LastObservation(scheduler_note=None)
-        for obs in observations_list:
-            count_feature.add_observation(obs)
+        for obs, indx in zip(observations_list, list_of_hpids):
+            count_feature.add_observation(obs, indx=indx)
         self.assertTrue(count_feature.feature["mjd"] == observations_list[-1]["mjd"])
         # and count again using add_observations_array
         count_feature = features.LastObservation(scheduler_note=None)
@@ -460,10 +492,11 @@ class TestFeatures(unittest.TestCase):
         for obs in observations_list:
             count_feature.add_observation(obs)
         self.assertTrue(count_feature.feature["mjd"] == observations_list[-1]["mjd"])
-        # and count again using add_observations_array
+        # and count again (with different note) using add_observations_array
         count_feature = features.LastObservation(scheduler_note="survey a")
         count_feature.add_observations_array(observations_array, observations_hpid=observations_hpid_array)
         self.assertTrue(count_feature.feature["mjd"] == observations_list[-2]["mjd"])
+
         # Observations matching a subset of note.
         count_feature = features.LastObservation(scheduler_note="survey")
         for obs in observations_list:
@@ -498,7 +531,9 @@ class TestFeatures(unittest.TestCase):
             else:
                 obs["scheduler_note"] = "survey"
             indexes.append(pointing2hpindx(obs["RA"], obs["dec"], rotSkyPos=obs["rotSkyPos"]))
-        observations_array, observations_hpid_array = make_observations_arrays(observations_list)
+        observations_array, observations_hpid_array, list_of_hpids = make_observations_arrays(
+            observations_list
+        )
         # Observations matching any note or filter
         count_feature = features.NObservations(filtername=None, scheduler_note=None)
         for obs, indx in zip(observations_list, indexes):

--- a/tests/scheduler/test_simple_examples.py
+++ b/tests/scheduler/test_simple_examples.py
@@ -128,9 +128,9 @@ class TestSurveyConveniences(unittest.TestCase):
         field_obs = observations[np.where(observations["target_name"] == "almost_cosmos")]
         self.assertTrue(field_obs.size > 200)
         self.assertTrue(np.all(field_obs["science_program"] == "BLOCK-TEST"))
-        self.assertTrue(field[0].extra_features["ObsRecorded"].feature == field_obs.size)
+        self.assertTrue(field[0].extra_features["ObsRecorded_note"].feature == field_obs.size)
         self.assertTrue(
-            np.abs(field_obs[-1]["mjd"] - field[0].extra_features["LastObs"].feature["mjd"])
+            np.abs(field_obs[-1]["mjd"] - field[0].extra_features["LastObs_note"].feature["mjd"])
             < 15 / 60 / 60 / 24
         )
 

--- a/tests/scheduler/test_skyarea.py
+++ b/tests/scheduler/test_skyarea.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 
+import healpy as hp
 import numpy as np
 
 from rubin_scheduler.data import get_data_dir
@@ -8,6 +9,7 @@ from rubin_scheduler.scheduler.utils import (
     EuclidOverlapFootprint,
     SkyAreaGenerator,
     SkyAreaGeneratorGalplane,
+    generate_all_sky,
     make_rolling_footprints,
 )
 
@@ -99,6 +101,15 @@ class TestSkyArea(unittest.TestCase):
         # This doesn't always have to be the case, but should be with defaults
         lowdust = np.where(labels == "lowdust")
         self.assertTrue(np.all(footprints["r"][lowdust] == 1))
+
+    def test_generate_all_sky(self):
+        # Test that the utility generate_all_sky returns appropriately
+        nside = 32
+        sky = generate_all_sky(nside=nside)
+        expected_keys = ["map", "ra", "dec", "eclip_lat", "eclip_lon", "gal_lat", "gal_lon"]
+        for k in expected_keys:
+            self.assertTrue(k in sky.keys())
+        self.assertEqual(sky["ra"].size, hp.nside2npix(nside))
 
 
 if __name__ == "__main__":

--- a/tests/scheduler/test_surveys.py
+++ b/tests/scheduler/test_surveys.py
@@ -79,7 +79,7 @@ class TestSurveys(unittest.TestCase):
         self.assertIsInstance(reward, float)
         reward_df = survey.make_reward_df(conditions)
         self.assertIsInstance(reward_df, pd.DataFrame)
-        reward_df = survey.make_reward_df(conditions, accum=False)
+        _ = survey.make_reward_df(conditions, accum=False)
 
     def test_field_survey_add_observations(self):
         nside = 32
@@ -104,40 +104,32 @@ class TestSurveys(unittest.TestCase):
         observations_array, observations_hpid_array = make_observations_arrays(observations_list)
 
         # Try adding observations to survey one at a time.
-        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, accept_obs=None)
+        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0)
         for obs, indx in zip(observations_list, indexes):
             survey.add_observation(obs, indx=indx)
         self.assertTrue(survey.extra_features["ObsRecorded"].feature == len(observations_list))
         self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[-1]["mjd"])
         # Try adding observations to survey in array
-        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, accept_obs=None)
+        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0)
         survey.add_observations_array(observations_array, observations_hpid_array)
         self.assertTrue(survey.extra_features["ObsRecorded"].feature == len(observations_list))
         self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[-1]["mjd"])
 
-        # Now with specific requirements on obs to accept.
-        # Try adding observations to survey one at a time.
-        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, accept_obs=["r band"])
+        # Now with different scheduler_notes.
+        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, scheduler_note="r band")
         for obs, indx in zip(observations_list, indexes):
             survey.add_observation(obs, indx=indx)
-        self.assertTrue(survey.extra_features["ObsRecorded"].feature == 5)
-        self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[4]["mjd"])
-        # Try adding observations to survey in array
-        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, accept_obs=["r band"])
-        survey.add_observations_array(observations_array, observations_hpid_array)
-        self.assertTrue(survey.extra_features["ObsRecorded"].feature == 5)
-        self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[4]["mjd"])
-        # Try adding observations to survey one at a time.
-        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, accept_obs=["r band", "g band"])
-        for obs, indx in zip(observations_list, indexes):
-            survey.add_observation(obs, indx=indx)
-        self.assertTrue(survey.extra_features["ObsRecorded"].feature == 10)
+        self.assertTrue(survey.extra_features["ObsRecorded"].feature == len(observations_list))
         self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[-1]["mjd"])
+        self.assertTrue(survey.extra_features["ObsRecorded_match"].feature == 5)
+        self.assertTrue(survey.extra_features["LastObs_match"].feature["mjd"] == observations_list[4]["mjd"])
         # Try adding observations to survey in array
-        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, accept_obs=["r band", "g band"])
+        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, scheduler_note="r band")
         survey.add_observations_array(observations_array, observations_hpid_array)
-        self.assertTrue(survey.extra_features["ObsRecorded"].feature == 10)
+        self.assertTrue(survey.extra_features["ObsRecorded"].feature == len(observations_list))
         self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[-1]["mjd"])
+        self.assertTrue(survey.extra_features["ObsRecorded_match"].feature == 5)
+        self.assertTrue(survey.extra_features["LastObs_match"].feature["mjd"] == observations_list[4]["mjd"])
 
     def test_pointings_survey(self):
         """Test the pointing survey."""

--- a/tests/scheduler/test_surveys.py
+++ b/tests/scheduler/test_surveys.py
@@ -121,15 +121,15 @@ class TestSurveys(unittest.TestCase):
             survey.add_observation(obs, indx=indx)
         self.assertTrue(survey.extra_features["ObsRecorded"].feature == len(observations_list))
         self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[-1]["mjd"])
-        self.assertTrue(survey.extra_features["ObsRecorded_match"].feature == 5)
-        self.assertTrue(survey.extra_features["LastObs_match"].feature["mjd"] == observations_list[4]["mjd"])
+        self.assertTrue(survey.extra_features["ObsRecorded_note"].feature == 5)
+        self.assertTrue(survey.extra_features["LastObs_note"].feature["mjd"] == observations_list[4]["mjd"])
         # Try adding observations to survey in array
         survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, scheduler_note="r band")
         survey.add_observations_array(observations_array, observations_hpid_array)
         self.assertTrue(survey.extra_features["ObsRecorded"].feature == len(observations_list))
         self.assertTrue(survey.extra_features["LastObs"].feature["mjd"] == observations_list[-1]["mjd"])
-        self.assertTrue(survey.extra_features["ObsRecorded_match"].feature == 5)
-        self.assertTrue(survey.extra_features["LastObs_match"].feature["mjd"] == observations_list[4]["mjd"])
+        self.assertTrue(survey.extra_features["ObsRecorded_note"].feature == 5)
+        self.assertTrue(survey.extra_features["LastObs_note"].feature["mjd"] == observations_list[4]["mjd"])
 
     def test_pointings_survey(self):
         """Test the pointing survey."""

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -108,7 +108,7 @@ class TestUtils(unittest.TestCase):
             mjd=observations[-1]["mjd"],
             mjd_start=mjd_start,
             kinem_model=km,
-            tel_az_limits=[
+            sky_az_limits=[
                 [az_min, az_max],
             ],
         )
@@ -128,7 +128,7 @@ class TestUtils(unittest.TestCase):
         forbidden = np.where((az > az_max) & (az < az_min))[0]
         # Some visits will occur in this forbidden range, due to
         # some complications about the shadow mask and pair completion
-        # Since this is like a "preference" when set with tel_az_limits,
+        # Since this is like a "preference" when set with sky_az_limits,
         # should allow some to occur in this set of forbidden azimuths
         second_pairs = [
             scheduler_note
@@ -143,7 +143,7 @@ class TestUtils(unittest.TestCase):
             mjd=observations[-1]["mjd"],
             mjd_start=mjd_start,
             kinem_model=km,
-            tel_alt_limits=[
+            sky_alt_limits=[
                 [alt_min, alt_max],
             ],
         )


### PR DESCRIPTION
Defines tel_alt_limits and tel_az_limits as the kinematic / observatory model limits for alt and az.
Defines sky_alt_limits and sky_az_limits as the on-sky (potentially disjoint) limits for alt and az.

Remove empty_observation and scheduler_observation completely.
Remove unused kwargs for FieldSurvey (reward_value and nexp). 