### PR TITLE
remove core sched rotator checking. add whole queue kwarg to request_…

### DIFF
--- a/tests/scheduler/test_coresched.py
+++ b/tests/scheduler/test_coresched.py
@@ -27,6 +27,11 @@ class TestCoreSched(unittest.TestCase):
         obs = scheduler.request_observation()
         assert obs is not None
 
+        # check that we can pull the whole queue
+        obs_list = scheduler.request_observation(whole_queue=True)
+        assert obs_list is not None
+        assert len(scheduler.queue) == 0
+
         # Check that we can flush the Queue
         scheduler.flush_queue()
         assert len(scheduler.queue) == 0


### PR DESCRIPTION
Remove some rotator checking that's in `CoreScheduler`.
Add a kwarg to return the whole observing queue rather than a single observation.