### PR TITLE
tickets/SP-1667: support reading multiple nights

### DIFF
--- a/rubin_scheduler/utils/consdb.py
+++ b/rubin_scheduler/utils/consdb.py
@@ -110,10 +110,13 @@ class ConsDBVisits(ABC):
         The date for which to query the database.
     url : `str`
         The connection string from the database.
+    num_nights : `int`
+        The number of nights (ending in day_obs) for which to get visits.
     """
 
     day_obs: str | int
     url: str = "postgresql://usdf@usdf-summitdb.slac.stanford.edu:5432/exposurelog"
+    num_nights: int = 1
 
     @property
     @abstractmethod
@@ -314,7 +317,8 @@ class ConsDBVisits(ABC):
                 AND e.s_dec IS NOT NULL
                 AND e.sky_rotation IS NOT NULL
                 AND ((e.band IS NOT NULL) OR (e.physical_filter IS NOT NULL))
-                AND e.day_obs = {self.day_obs_int}
+                AND e.day_obs <= {self.day_obs_int}
+                AND e.day_obs > {self.day_obs_int - self.num_nights}
         """
         return query_consdb(consdb_visits_query, self.url)
 

--- a/rubin_scheduler/utils/consdb.py
+++ b/rubin_scheduler/utils/consdb.py
@@ -2,6 +2,7 @@ import importlib.util
 import urllib.parse
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from functools import cache, cached_property
 from math import log, sqrt
 from warnings import warn
@@ -111,7 +112,8 @@ class ConsDBVisits(ABC):
     url : `str`
         The connection string from the database.
     num_nights : `int`
-        The number of nights (ending in day_obs) for which to get visits.
+        The number of nights (up to and including day_obs)
+        for which to get visits. Defaults to 1.
     """
 
     day_obs: str | int
@@ -308,6 +310,10 @@ class ConsDBVisits(ABC):
         # and visit_id = exposure_id.
         # To support 2 exposures snaps in the future, this query will
         # need to be rewritten to group by visit_id.
+        day_obs_date = datetime.strptime(f"{self.day_obs_int}", "%Y%m%d").date()
+        prior_day_obs_date = day_obs_date - timedelta(days=self.num_nights)
+        prior_day_obs_int = int(prior_day_obs_date.strftime("%Y%m%d"))
+
         consdb_visits_query: str = f"""
             SELECT * FROM cdb_{self.instrument}.exposure AS e
             LEFT JOIN cdb_{self.instrument}.visit{self.num_exposures}_quicklook
@@ -318,7 +324,7 @@ class ConsDBVisits(ABC):
                 AND e.sky_rotation IS NOT NULL
                 AND ((e.band IS NOT NULL) OR (e.physical_filter IS NOT NULL))
                 AND e.day_obs <= {self.day_obs_int}
-                AND e.day_obs > {self.day_obs_int - self.num_nights}
+                AND e.day_obs > {prior_day_obs_int}
         """
         return query_consdb(consdb_visits_query, self.url)
 


### PR DESCRIPTION
Previously, the consdb tools in rubin_scheduler could only query visits for one night at a time. To support DDF cadence plots (needed to merge the different version of the night summary for SP-1667), all nights to be included in the DDF plot should be queryable at once.