### PR TITLE
Fix bug in CameraRotSmallDitherDetailer

### DIFF
--- a/rubin_scheduler/scheduler/detailers/dither_detailer.py
+++ b/rubin_scheduler/scheduler/detailers/dither_detailer.py
@@ -361,6 +361,7 @@ class CameraSmallRotPerObservationListDetailer(BaseDetailer):
             # (we'll wipe this when we get to next fchange_idx)
             offsets[fchange_idx:] += self.per_visit_rot * np.arange(len(filter_list) - fchange_idx)
 
+		offsets = np.where(offsets > self.max_rot, max_rot, offsets)
         return offsets
 
     def __call__(self, observation_list, conditions):

--- a/rubin_scheduler/scheduler/detailers/dither_detailer.py
+++ b/rubin_scheduler/scheduler/detailers/dither_detailer.py
@@ -356,7 +356,7 @@ class CameraSmallRotPerObservationListDetailer(BaseDetailer):
         for fchange_idx, nvis_f in zip(filter_changes, nvis_per_filter):
             rot_range = self.rot_range - self.per_visit_rot * nvis_f
             # At the filter change spot, update to random offset
-            offsets[fchange_idx] = rng.random() * rot_range + self.min_rot
+            offsets[fchange_idx:] = rng.random() * rot_range + self.min_rot
             # After the filter change point, add incremental rotation
             # (we'll wipe this when we get to next fchange_idx)
             offsets[fchange_idx:] += self.per_visit_rot * np.arange(len(filter_list) - fchange_idx)


### PR DESCRIPTION
CameraRotSmallDitherDetailer was losing the large offsets to rotation angle between filter changes after the first visit in each filter in a sequence, and going back to only keeping the small per-visit offset. 