### PR TITLE
move band to filter mapping to CoreScheduler

### DIFF
--- a/rubin_scheduler/scheduler/surveys/base_survey.py
+++ b/rubin_scheduler/scheduler/surveys/base_survey.py
@@ -7,7 +7,7 @@ import healpy as hp
 import numpy as np
 import pandas as pd
 
-from rubin_scheduler.scheduler.detailers import BandToFilterDetailer, TrackingInfoDetailer, ZeroRotDetailer
+from rubin_scheduler.scheduler.detailers import TrackingInfoDetailer, ZeroRotDetailer
 from rubin_scheduler.scheduler.utils import (
     HpInLsstFov,
     ObservationArray,
@@ -130,19 +130,6 @@ class BaseSurvey:
                     science_program=science_program,
                     observation_reason=observation_reason,
                 )
-            )
-        # There always needs to be a BandToFilterDetailer, to fill in
-        # 'filter' information for ts_scheduler.
-        # Check if one exists, add a default if it doesn't.
-        existing_band_to_filter = False
-        for detailer in self.detailers:
-            if isinstance(detailer, BandToFilterDetailer):
-                existing_band_to_filter = True
-        if not existing_band_to_filter:
-            self.detailers.append(
-                # Set up a detailer that just uses the survey configuration
-                # band information (which could be band or physical filtername)
-                BandToFilterDetailer(band_to_filter_dict={})
             )
 
     @cached_property

--- a/rubin_scheduler/scheduler/surveys/too_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_surveys.py
@@ -21,6 +21,8 @@ class TooMaster(BaseSurvey):
     """
 
     def __init__(self, example__to_o_survey):
+        message = "TooMaster unused and planned to be deprecated."
+        warnings.warn(message, FutureWarning)
         self.example__to_o_survey = example__to_o_survey
         self.surveys = []
         self.highest_reward = -np.inf
@@ -124,6 +126,8 @@ class TooSurvey(BlobSurvey):
         filtername2=None,
         filter_change_approx=None,
     ):
+        message = "TooSurvey unused and planned to be deprecated."
+        warnings.warn(message, FutureWarning)
         if filtername1 is not None:
             warnings.warn("filtername1 deprecated in favor of bandname1", FutureWarning)
             bandname1 = filtername1


### PR DESCRIPTION
Subclasses of the `Survey` object do not always run the base `__init__` method, so can fail to map band to filter.