### PR TITLE
SP-1686: Add a subclass of rubin_scheduler.utils.consdb.ConsDBVisits to support latiss

### DIFF
--- a/tests/utils/test_consdb.py
+++ b/tests/utils/test_consdb.py
@@ -8,10 +8,35 @@ from rubin_scheduler.utils.consdb import ConsDBVisits, load_consdb_visits
 
 
 class TestConsdb(unittest.TestCase):
+
     @unittest.skip("avoid requiring access to consdb for tests.")
-    def test_consdb_read_visits_quick(self):
+    def test_consdb_read_visits_comcamsim(self):
         day_obs: str = "2024-06-26"
         consdb_visits: ConsDBVisits = load_consdb_visits("lsstcomcamsim", day_obs)
+        schema_converter: SchemaConverter = SchemaConverter()
+
+        opsim: pd.DataFrame = consdb_visits.opsim
+        schema_converter.opsimdf2obs(opsim)
+
+        obs: np.recarray = consdb_visits.obs
+        schema_converter.obs2opsim(obs)
+
+    @unittest.skip("avoid requiring access to consdb for tests.")
+    def test_consdb_read_visits_comcam(self):
+        day_obs: str = "2024-12-10"
+        consdb_visits: ConsDBVisits = load_consdb_visits("lsstcomcam", day_obs)
+        schema_converter: SchemaConverter = SchemaConverter()
+
+        opsim: pd.DataFrame = consdb_visits.opsim
+        schema_converter.opsimdf2obs(opsim)
+
+        obs: np.recarray = consdb_visits.obs
+        schema_converter.obs2opsim(obs)
+
+    @unittest.skip("avoid requiring access to consdb for tests.")
+    def test_consdb_read_visits_latiss(self):
+        day_obs: str = "2025-03-03"
+        consdb_visits: ConsDBVisits = load_consdb_visits("latiss", day_obs)
         schema_converter: SchemaConverter = SchemaConverter()
 
         opsim: pd.DataFrame = consdb_visits.opsim


### PR DESCRIPTION
The code added assumes that the units of sky_db are ADU. It isn't presently filled out and I don't know the gain anyway, so the sky column returned ends up nan anyway, but what it should be should be checked.
Similarly, I have assumed the use of zero point I used for comcam will apply to latiss as well.
(I'm not 100% sure what I have there works even for comcam any more, because I recall discussion of converting things from ADU to electrons after I wrote this, and I don't know if the usage in consdb changed or not.)