### PR TITLE
tickets/SP-2013: switch to using the REST API for consdb in rubin_scheduler so it can work from anywhere with a token

### DIFF
--- a/tests/utils/test_consdb.py
+++ b/tests/utils/test_consdb.py
@@ -21,10 +21,12 @@ class TestConsdb(unittest.TestCase):
         obs: np.recarray = consdb_visits.obs
         schema_converter.obs2opsim(obs)
 
-    @unittest.skip("avoid requiring access to consdb for tests.")
+    #    @unittest.skip("avoid requiring access to consdb for tests.")
     def test_consdb_read_visits_comcam(self):
         day_obs: str = "2024-12-10"
-        consdb_visits: ConsDBVisits = load_consdb_visits("lsstcomcam", day_obs)
+        consdb_visits: ConsDBVisits = load_consdb_visits(
+            "lsstcomcam", day_obs, url="https://usdf-rsp.slac.stanford.edu/consdb/query"
+        )
         schema_converter: SchemaConverter = SchemaConverter()
 
         opsim: pd.DataFrame = consdb_visits.opsim

--- a/tests/utils/test_consdb.py
+++ b/tests/utils/test_consdb.py
@@ -21,12 +21,10 @@ class TestConsdb(unittest.TestCase):
         obs: np.recarray = consdb_visits.obs
         schema_converter.obs2opsim(obs)
 
-    #    @unittest.skip("avoid requiring access to consdb for tests.")
+    @unittest.skip("avoid requiring access to consdb for tests.")
     def test_consdb_read_visits_comcam(self):
         day_obs: str = "2024-12-10"
-        consdb_visits: ConsDBVisits = load_consdb_visits(
-            "lsstcomcam", day_obs, url="https://usdf-rsp.slac.stanford.edu/consdb/query"
-        )
+        consdb_visits: ConsDBVisits = load_consdb_visits("lsstcomcam", day_obs)
         schema_converter: SchemaConverter = SchemaConverter()
 
         opsim: pd.DataFrame = consdb_visits.opsim


### PR DESCRIPTION
I have included a URL for the endpoint to be used at the summit, but at this point its just a guess based on the EFD URLs.
