### PR TITLE
SP-2902: Remove gitpython and conda following sim_archive move

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "requests",
     "shapely",
     "tqdm",
-    "gitpython",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ h5py
 requests
 shapely
 tqdm
-gitpython
-conda
+


### PR DESCRIPTION
Remove gitpython and conda from requirements.txt and pyproject.toml after moving the module that used these into rubin-sim. 