### PR TITLE
copy column detailer

### DIFF
--- a/rubin_scheduler/scheduler/detailers/detailer.py
+++ b/rubin_scheduler/scheduler/detailers/detailer.py
@@ -19,6 +19,7 @@ __all__ = (
     "StartFieldSequenceDetailer",
     "BandToFilterDetailer",
     "TagRadialDetailer",
+    "CopyValueDetailer",
 )
 
 import copy
@@ -680,3 +681,24 @@ class TagRadialDetailer(BaseDetailer):
             obsarray["scheduler_note"][in_region], self.note_append
         )
         return obsarray
+
+
+class CopyValueDetailer(BaseDetailer):
+    """Copy a value from one observation array column to another
+
+    Parameters
+    ----------
+    source : `str`
+        The name of the source column.
+    destination : `str`
+        Name of the destination column.
+    """
+
+    def __init__(self, source, destination):
+        super().__init__()
+        self.source = source
+        self.destination = destination
+
+    def __call__(self, obs_array, conditions):
+        obs_array[self.destination] = obs_array[self.source]
+        return obs_array

--- a/tests/scheduler/test_detailers.py
+++ b/tests/scheduler/test_detailers.py
@@ -185,6 +185,19 @@ class TestDetailers(unittest.TestCase):
         for out in output:
             assert out["filter"] == filtername_dict[out["band"]]
 
+    def test_copycol(self):
+
+        obs = ObservationArray(3)
+        obs["band"][0] = "r"
+        obs["band"][1] = "g"
+        obs["band"][2] = "g"
+
+        detailer = detailers.CopyValueDetailer("band", "filter")
+
+        output = detailer(obs, None)
+
+        assert np.array_equal(output["band"], output["filter"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Detailer so one can copy values from one column to another, e.g., `scheduler_note` to `target_id`.