### PR TITLE
Update too_scripted_surveys.py to remove duplicate detailers call

### DIFF
--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -160,7 +160,6 @@ class ToOScriptedSurvey(ScriptedSurvey, BaseMarkovSurvey):
             self.event_gen_detailers = event_gen_detailers
         self.dither = dither
         self.id_start = id_start
-        self.detailers = detailers
         self.last_mjd = -1
         self.too_types_to_follow = too_types_to_follow
         self.split_long = split_long


### PR DESCRIPTION
Very minor change, but a duplicate call of detailer definition on the ToO scripted survey is removed here.