### PR TITLE
SP-2378: Add 5-min sampled DDF grid

### DIFF
--- a/rubin_scheduler/data/scheduler_download_data.py
+++ b/rubin_scheduler/data/scheduler_download_data.py
@@ -27,7 +27,7 @@ def data_dict():
         "version" - Versioned file name (`str`).
     """
     file_dict = {
-        "scheduler": "scheduler_2025_05_28.tgz",
+        "scheduler": "scheduler_2025_06_27.tgz",
         "site_models": "site_models_2023_10_02.tgz",
         "skybrightness_pre": "skybrightness_pre_2024_11_19.tgz",
         "utils": "utils_2023_11_02.tgz",

--- a/rubin_scheduler/scheduler/surveys/generate_ddf_grid.py
+++ b/rubin_scheduler/scheduler/surveys/generate_ddf_grid.py
@@ -1,5 +1,6 @@
 __all__ = ("generate_ddf_grid",)
 
+import argparse
 import os
 import sys
 
@@ -9,7 +10,7 @@ from astropy.time import Time
 
 from rubin_scheduler.data import get_data_dir
 from rubin_scheduler.site_models.seeing_model import SeeingModel
-from rubin_scheduler.utils import Site, ddf_locations, m5_flat_sed
+from rubin_scheduler.utils import SURVEY_START_MJD, Site, ddf_locations, m5_flat_sed
 
 
 def generate_ddf_grid(
@@ -130,9 +131,23 @@ def generate_ddf_grid(
 
 
 if __name__ == "__main__":
-    # Generate a grid of airmass skybrightness values
-    # for each DDF in 15 minute intervals.
 
-    result = generate_ddf_grid()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--full",
+        dest="full",
+        action="store_true",
+        help="Compute 40 year grid at 15 min resolution. Default is 12 years at 5 min resolution.",
+    )
+    parser.set_defaults(full=False)
 
-    np.savez(os.path.join(get_data_dir(), "scheduler", "ddf_grid.npz"), ddf_grid=result)
+    args = parser.parse_args()
+
+    full = args.full
+
+    if full:
+        result = generate_ddf_grid()
+        np.savez(os.path.join(get_data_dir(), "scheduler", "ddf_grid.npz"), ddf_grid=result)
+    else:
+        result = generate_ddf_grid(verbose=True, mjd0=SURVEY_START_MJD - 365, delta_t=5.0, survey_length=12.0)
+        np.savez(os.path.join(get_data_dir(), "scheduler", "ddf_grid_fine.npz"), ddf_grid=result)


### PR DESCRIPTION
Update so we have 15 min and 5 min DDF pre-computed resolution files. 