### PR TITLE
tickets/SP-2444: stop-gap to support getting only sv visits

### DIFF
--- a/rubin_scheduler/utils/consdb.py
+++ b/rubin_scheduler/utils/consdb.py
@@ -159,12 +159,15 @@ class ConsDBVisits(ABC):
         File from which to load the token. If `None`, use the ``lsst.rsp``
         (if available) or the ``ACCESS_TOKEN`` environment variable.
         Defaults to `None`.
+    constraints : `str`
+        Additional constraints in the SQL query to send to consdb.
     """
 
     day_obs: str | int
     url: str | None = None
     num_nights: int = 1
     token_file: str | None = None
+    constraints: str = ""
 
     def _have_numeric_values(self, column) -> bool:
         if column not in self.consdb_visits.columns:
@@ -371,6 +374,9 @@ class ConsDBVisits(ABC):
                 AND v.day_obs <= {self.day_obs_int}
                 AND v.day_obs > {prior_day_obs_int}
         """
+        if len(self.constraints) > 0:
+            consdb_visits_query += f" AND ({self.constraints})"
+
         return query_consdb(consdb_visits_query, self.url, self.token_file)
 
     @cached_property

--- a/tests/utils/test_consdb.py
+++ b/tests/utils/test_consdb.py
@@ -13,6 +13,27 @@ from rubin_scheduler.utils.consdb import ConsDBVisits, load_consdb_visits
 class TestConsdb(unittest.TestCase):
 
     @unittest.skip("avoid requiring access to consdb for tests.")
+    def test_consdb_read_visits_lsstcam(self):
+        day_obs: str = "2025-07-01"
+        consdb_visits: ConsDBVisits = load_consdb_visits("lsstcam", day_obs)
+        schema_converter: SchemaConverter = SchemaConverter()
+
+        opsim: pd.DataFrame = consdb_visits.opsim
+        schema_converter.opsimdf2obs(opsim)
+
+        obs: np.recarray = consdb_visits.obs
+        schema_converter.obs2opsim(obs)
+
+    @unittest.skip("avoid requiring access to consdb for tests.")
+    def test_consdb_read_visits_with_constraints(self):
+        day_obs: str = "2025-07-01"
+        constraints = "band = 'z'"
+        consdb_visits: ConsDBVisits = load_consdb_visits("lsstcam", day_obs, constraints=constraints)
+        opsim: pd.DataFrame = consdb_visits.opsim
+        assert len(opsim) > 0
+        assert np.all(opsim.band == "z")
+
+    @unittest.skip("avoid requiring access to consdb for tests.")
     def test_consdb_read_visits_comcamsim(self):
         day_obs: str = "2024-06-26"
         consdb_visits: ConsDBVisits = load_consdb_visits("lsstcomcamsim", day_obs)


### PR DESCRIPTION
This a a short-term fix to support querying just SV visits until we work through SP-2442.