### PR TITLE
Update too_scripted_surveys.py to have one field per healpix pixel

### DIFF
--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -16,8 +16,8 @@ from rubin_scheduler.scheduler.utils import (
     thetaphi2xyz,
     xyz2thetaphi,
 )
-# from rubin_scheduler.site_models import _read_fields # commenting out, following stopgap
-# solution for pointings
+# from rubin_scheduler.site_models import _read_fields # commenting 
+# out, following stopgap solution for pointings
 from rubin_scheduler.utils import DEFAULT_NSIDE, _approx_ra_dec2_alt_az, _ra_dec2_hpid
 
 
@@ -174,7 +174,7 @@ class ToOScriptedSurvey(ScriptedSurvey, BaseMarkovSurvey):
             ### Stopgap attempt - SM ###
             def IndexToDeclRa(index,NSIDE): # Helper function
                 theta,phi=hp.pixelfunc.pix2ang(NSIDE,index)
-                return -np.degrees(theta-np.pi/2.),np.degrees(pi*2.-phi)
+                return -np.degrees(theta-np.pi/2.),np.degrees(np.pi*2.-phi)
             npix = 12*self.nside**2 # Total pix in skymap
             ra, dec = [],[]
             for ind in range(npix):

--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -16,7 +16,7 @@ from rubin_scheduler.scheduler.utils import (
     thetaphi2xyz,
     xyz2thetaphi,
 )
-# from rubin_scheduler.site_models import _read_fields # commenting 
+# from rubin_scheduler.site_models import _read_fields # commenting
 # out, following stopgap solution for pointings
 from rubin_scheduler.utils import DEFAULT_NSIDE, _approx_ra_dec2_alt_az, _ra_dec2_hpid
 

--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -21,6 +21,7 @@ from rubin_scheduler.utils import DEFAULT_NSIDE, _approx_ra_dec2_alt_az, _ra_dec
 # from rubin_scheduler.site_models import _read_fields
 # commenting out, following stopgap solution for pointings
 
+
 def rotx(theta, x, y, z):
     """rotate the x,y,z points theta radians about x axis"""
     sin_t = np.sin(theta)
@@ -172,13 +173,14 @@ class ToOScriptedSurvey(ScriptedSurvey, BaseMarkovSurvey):
         # Load the OpSim field tesselation and map healpix to fields
         if self.camera == "LSST":
             ### Stopgap attempt - SM ###
-            def IndexToDeclRa(index,NSIDE): # Helper function
-                theta,phi=hp.pixelfunc.pix2ang(NSIDE,index)
-                return -np.degrees(theta-np.pi/2.),np.degrees(np.pi*2.-phi)
-            npix = 12*self.nside**2 # Total pix in skymap
-            ra, dec = [],[]
+            def IndexToDeclRa(index, NSIDE):  # Helper function
+                theta, phi = hp.pixelfunc.pix2ang(NSIDE, index)
+                return -np.degrees(theta - np.pi / 2.0), np.degrees(np.pi * 2.0 - phi)
+
+            npix = 12 * self.nside**2  # Total pix in skymap
+            ra, dec = [], []
             for ind in range(npix):
-                dec_ra = IndexToDeclRa(ind,self.nside)
+                dec_ra = IndexToDeclRa(ind, self.nside)
                 dec.append(np.radians(dec_ra[0]))
                 ra.append(np.radians(dec_ra[1]))
             ### End stopgap attempt ###

--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -16,7 +16,8 @@ from rubin_scheduler.scheduler.utils import (
     thetaphi2xyz,
     xyz2thetaphi,
 )
-from rubin_scheduler.site_models import _read_fields
+# from rubin_scheduler.site_models import _read_fields # commenting out, following stopgap
+# solution for pointings
 from rubin_scheduler.utils import DEFAULT_NSIDE, _approx_ra_dec2_alt_az, _ra_dec2_hpid
 
 
@@ -171,13 +172,13 @@ class ToOScriptedSurvey(ScriptedSurvey, BaseMarkovSurvey):
         # Load the OpSim field tesselation and map healpix to fields
         if self.camera == "LSST":
             ### Stopgap attempt - SM ###
-            def IndexToDeclRa(index): # Helper function
+            def IndexToDeclRa(index,NSIDE): # Helper function
                 theta,phi=hp.pixelfunc.pix2ang(NSIDE,index)
-                return -np.degrees(theta-pi/2.),np.degrees(pi*2.-phi)
+                return -np.degrees(theta-np.pi/2.),np.degrees(pi*2.-phi)
             npix = 12*self.nside**2 # Total pix in skymap
             ra, dec = [],[]
             for ind in range(npix):
-                dec_ra = IndexToDeclRa(ind)
+                dec_ra = IndexToDeclRa(ind,self.nside)
                 dec.append(np.radians(dec_ra[0]))
                 ra.append(np.radians(dec_ra[1]))
             ### End stopgap attempt ###

--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -16,10 +16,10 @@ from rubin_scheduler.scheduler.utils import (
     thetaphi2xyz,
     xyz2thetaphi,
 )
-# from rubin_scheduler.site_models import _read_fields # commenting
-# out, following stopgap solution for pointings
 from rubin_scheduler.utils import DEFAULT_NSIDE, _approx_ra_dec2_alt_az, _ra_dec2_hpid
 
+# from rubin_scheduler.site_models import _read_fields
+# commenting out, following stopgap solution for pointings
 
 def rotx(theta, x, y, z):
     """rotate the x,y,z points theta radians about x axis"""

--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -184,7 +184,7 @@ class ToOScriptedSurvey(ScriptedSurvey, BaseMarkovSurvey):
                 dec.append(np.radians(dec_ra[0]))
                 ra.append(np.radians(dec_ra[1]))
             ### End stopgap attempt ###
-            self.fields_init = np.empty(ra.size, dtype=list(zip(["RA", "dec"], [float, float])))
+            self.fields_init = np.empty(len(ra), dtype=list(zip(["RA", "dec"], [float, float])))
             self.fields_init["RA"] = ra
             self.fields_init["dec"] = dec
         elif self.camera == "comcam":

--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -170,7 +170,17 @@ class ToOScriptedSurvey(ScriptedSurvey, BaseMarkovSurvey):
         self.camera = camera
         # Load the OpSim field tesselation and map healpix to fields
         if self.camera == "LSST":
-            ra, dec = _read_fields()
+            ### Stopgap attempt - SM ###
+            def IndexToDeclRa(index): # Helper function
+                theta,phi=hp.pixelfunc.pix2ang(NSIDE,index)
+                return -np.degrees(theta-pi/2.),np.degrees(pi*2.-phi)
+            npix = 12*self.nside**2 # Total pix in skymap
+            ra, dec = [],[]
+            for ind in range(npix):
+                dec_ra = IndexToDeclRa(ind)
+                dec.append(np.radians(dec_ra[0]))
+                ra.append(np.radians(dec_ra[1]))
+            ### End stopgap attempt ###
             self.fields_init = np.empty(ra.size, dtype=list(zip(["RA", "dec"], [float, float])))
             self.fields_init["RA"] = ra
             self.fields_init["dec"] = dec


### PR DESCRIPTION
Here, I make an attempt to improve the fields for the ToOScriptedSurvey class.

This change gives each healpix pixel a single pointing. For our current `nside=32` implementation, this means a mean spacing of ~1.8 deg^2. While this is still not optimal, it is already an improvement ahead of the current implementation which has anywhere from 3-4 pointings within a single healpix pixel.

Longer term, each ToO event should have its own pointing grid created, but that is a larger conversation outside of this immediate scope