### PR TITLE
Update too_scripted_surveys.py to iterate over filters before visits

### DIFF
--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -349,21 +349,21 @@ class ToOScriptedSurvey(ScriptedSurvey, BaseMarkovSurvey):
                     self.exptimes,
                     np.arange(np.size(self.times)),
                 ):
-                    for i in range(nv):
-                        # let's dither each pointing
-                        if (i != 0) & (hpid_to_observe.size > 0):
-                            ras, decs = self._tesselate(hpid_to_observe)
+                    for bandname in bandnames:
+                        # Subsitute y for z if needed on first observation
+                        if i == 0:
+                            if (bandname == "z") & (bandname not in conditions.mounted_bands):
+                                bandname = "y"
+    
+                        if bandname == "u":
+                            nexp = self.n_usnaps
+                        else:
+                            nexp = self.n_snaps
 
-                        for bandname in bandnames:
-                            # Subsitute y for z if needed on first observation
-                            if i == 0:
-                                if (bandname == "z") & (bandname not in conditions.mounted_bands):
-                                    bandname = "y"
-
-                            if bandname == "u":
-                                nexp = self.n_usnaps
-                            else:
-                                nexp = self.n_snaps
+                        for i in range(nv):
+                            # let's dither each pointing
+                            if (i != 0) & (hpid_to_observe.size > 0):
+                                ras, decs = self._tesselate(hpid_to_observe)
 
                             # If we are doing a short exposure
                             # need to be 1 snap for shutter limits


### PR DESCRIPTION
In the current implementation, we iterate over filter before iterating over visits. For four pointings, with two visits, each in r and i band, that looks like 

> r1, r2, r3, r4, i1, i2, i3, i4, r1, r2, r3, r4, i1, i2, i3, i4

where the integer represents the pointing number. This increases the total number of filter changes, and is not optimal for maximizing the open shutter fraction. 

This PR aims to swap the iteration order, instead iterating over visits before iterating over filters. For the example above, the intended behavior is then 

> r1, r2, r3, r4, i1, i2, i3, i4, r1, r2, r3, r4, i1, i2, i3, i4

For most science cases, the usage of multiple visits is to coadd images to reach a desired depth before performing DIA. One example of this is the GW NS gold case, which requests 180/120s of exposure time for visit epochs, which cannot be accomplished by simply increasing the exposure time for a single visit due to saturation limits.

If this is not the best way to do this, please let me know.