### PR TITLE
Update too_scripted_surveys.py to have updated exposure times and visit numbers

### DIFF
--- a/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
+++ b/rubin_scheduler/scheduler/surveys/too_scripted_surveys.py
@@ -551,7 +551,7 @@ def gen_too_surveys(
 
     times = [0, 2, 4, 24, 48, 72]
     bands_at_times = ["gri", "gri", "gri", "ri", "ri", "ri"]
-    nvis = [4,4,4, 6,6,6]
+    nvis = [4, 4, 4, 6, 6, 6]
     exptimes = [30.0, 30.0, 30.0, 30.0, 30.0, 30.0]
     result.append(
         ToOScriptedSurvey(
@@ -581,7 +581,7 @@ def gen_too_surveys(
     times = [0, 24, 48, 72]
     bands_at_times = ["gi", "gi", "gi", "gi"]
     nvis = [1, 4, 4, 4]
-    exptimes = [30.0,30.0,30.0,30.0]
+    exptimes = [30.0, 30.0, 30.0, 30.0]
     result.append(
         ToOScriptedSurvey(
             bf_list,
@@ -659,7 +659,7 @@ def gen_too_surveys(
     times = np.array([1.0, 1.0, 25, 25, 49, 49])
     bands_at_times = ["g", "r"] * 3
     nvis = [1, 3] * 3
-    exptimes = [DEFAULT_EXP_TIME,DEFAULT_EXP_TIME] * 3
+    exptimes = [DEFAULT_EXP_TIME, DEFAULT_EXP_TIME] * 3
 
     result.append(
         ToOScriptedSurvey(


### PR DESCRIPTION
From a camera safety perspective, exposures longer than 30s (especially 120 and 180s) poses a significant risk of tripping HV on the camera, which has many cascading effects. 

For this reason, I revised the exposure times and visit numbers in the ToO surveys to ensure that the necessary depth is still achieved while keeping the Camera safe. 

To perform the image coaddition, work is needed on the image processing side. This is the route that is being employed by the bespoke image processing pipeline, and we will take the lessons learned from that process forward to the automated implementation.