### PR TITLE
Add DateSwapBandScheduler

### DIFF
--- a/rubin_scheduler/scheduler/schedulers/filter_scheduler.py
+++ b/rubin_scheduler/scheduler/schedulers/filter_scheduler.py
@@ -1,6 +1,7 @@
-__all__ = ("BandSwapScheduler", "SimpleBandSched", "ComCamBandSched", "BandSchedUzy")
+__all__ = ("BandSwapScheduler", "SimpleBandSched", "ComCamBandSched", "BandSchedUzy", "DateSwapBandScheduler")
 
 import numpy as np
+from astropy.time import Time
 
 from rubin_scheduler.scheduler.utils import IntRounded
 
@@ -24,6 +25,19 @@ class BandSwapScheduler:
 
 
 class SimpleBandSched(BandSwapScheduler):
+    """Swap the mounted bands depending on the lunar phase.
+
+    This assumes we swap between just two sets of bandpasses, one
+    for lunar phases where moon illumination at sunset < `illum_limit` and
+    another for phases > `illum_limit`.
+
+    Parameters
+    ----------
+    illum_limit
+        The illumination limit to be compared to the `moon_illum`
+        reported by the `Almanac`.
+    """
+
     def __init__(self, illum_limit=10.0):
         self.illum_limit_ir = IntRounded(illum_limit)
 
@@ -109,3 +123,80 @@ class BandSchedUzy(BandSwapScheduler):
             if result != conditions.mounted_bands:
                 self.last_swap += 1
         return result
+
+
+class DateSwapBandScheduler(BandSwapScheduler):
+    """Swap specific bands on specific days, up until end_date, then
+    fall back to the backup_filter_scheduler.
+
+    This provides a way for simulations to use the specific bands that
+    were in use on specific nights, as well as to incorporate knowledge
+    of the upcoming scheduler, while still falling back to a reasonable
+    filter swap schedule beyond the time the dates are precisely known.
+
+    Parameters
+    ----------
+    swap_schedule
+        Dictionary of times of the filter swaps, together with the filter
+        complement loaded into the carousel.
+        e.g. {Time("2025-08-05T12:00:00") : ['r', 'i', 'z', 'y']
+    end_date
+        The Time after which the dictionary is no longer valid and the
+        `backup_band_scheduler` should be used.
+    backup_band_scheduler
+        The more general band swap scheduler to use after the specific
+        dates of the dictionary are exhausted. This should match the
+        expected band scheduler for the Scheduler.
+    """
+
+    def __init__(
+        self,
+        swap_schedule: dict[Time, list[str]] | None = None,
+        end_date: Time | None = None,
+        backup_band_scheduler: BandSwapScheduler = SimpleBandSched(illum_limit=40),
+    ):
+        if swap_schedule is None:
+            # Current estimate for the SV survey.
+            # Subject to change, although past dates should match reality.
+            self.swap_schedule = {
+                Time("2025-08-05T12:00:00"): ["r", "i", "z", "y"],
+                Time("2025-08-12T12:00:00"): ["g", "r", "i", "z"],
+                Time("2025-08-19T12:00:00"): ["u", "g", "r", "i"],
+                Time("2025-08-26T12:00:00"): [
+                    "g",
+                    "r",
+                    "i",
+                    "z",
+                ],
+                Time("2025-09-02T12:00:00"): ["g", "r", "i", "y"],
+                Time("2025-09-09T12:00:00"): ["r", "i", "z", "y"],
+                Time("2025-09-16T12:00:00"): ["g", "r", "i", "z"],
+                Time("2025-09-21T12:00:00"): [
+                    "u",
+                    "g",
+                    "r",
+                    "i",
+                ],
+            }
+        else:
+            self.swap_schedule = swap_schedule
+
+        if end_date is None:
+            self.end_date = Time("2025-09-25T12:00:00")
+        else:
+            self.end_date = end_date
+
+        if backup_band_scheduler is None:
+            self.backup_band_scheduler = SimpleBandSched(illum_limit=40)
+        else:
+            self.backup_band_scheduler = backup_band_scheduler
+
+    def __call__(self, conditions):
+        current_time = Time(conditions.mjd, format="mjd", scale="tai")
+
+        if current_time < self.end_date:
+            idx = np.where(current_time >= list(self.swap_schedule.keys()))[0][-1]
+            return self.swap_schedule[list(self.swap_schedule.keys())[idx]]
+
+        else:
+            return self.backup_band_scheduler(conditions)

--- a/tests/scheduler/test_filterschedulers.py
+++ b/tests/scheduler/test_filterschedulers.py
@@ -1,9 +1,10 @@
 import unittest
 
 import numpy as np
+from astropy.time import Time
 
 from rubin_scheduler.scheduler.features import Conditions
-from rubin_scheduler.scheduler.schedulers import ComCamBandSched, SimpleBandSched
+from rubin_scheduler.scheduler.schedulers import ComCamBandSched, DateSwapBandScheduler, SimpleBandSched
 from rubin_scheduler.utils import SURVEY_START_MJD
 
 
@@ -45,6 +46,36 @@ class TestBandSchedulers(unittest.TestCase):
         conditions.moon_phase_sunset = 50
         load_bands = bandsched(conditions)
         self.assertTrue(load_bands == brightmoon_result)
+
+    def test_DateSwapBandScheduler(self):
+        # No specific arguments should be fine
+        bandsched = DateSwapBandScheduler()
+        # known time with known filters
+        tt = Time("2025-08-05T20:00:00")
+        conditions = Conditions(nside=8, mjd=tt.mjd)
+        self.assertEqual(bandsched(conditions), ["r", "i", "z", "y"])
+        # full moon, past the current end of the band scheduler
+        tt2 = Time("2025-11-05T20:00:00")
+        conditions = Conditions(nside=8, mjd=tt2.mjd)
+        conditions.moon_phase_sunset = 100
+        self.assertEqual(bandsched(conditions), ["g", "r", "i", "z", "y"])
+        # Set values
+        date_swaps = {Time("2025-08-05T12:00:00"): ["u", "g"], Time("2025-08-06T12:00:00"): ["z", "y"]}
+        end_date = Time("2025-08-07T12:00:00")
+        backup_band_scheduler = SimpleBandSched(illum_limit=50)
+        bandsched = DateSwapBandScheduler(
+            swap_schedule=date_swaps, end_date=end_date, backup_band_scheduler=backup_band_scheduler
+        )
+        tt = Time("2025-08-05T20:00:00")
+        conditions = Conditions(nside=8, mjd=tt.mjd)
+        self.assertEqual(bandsched(conditions), ["u", "g"])
+        tt = Time("2025-08-06T20:00:00")
+        conditions = Conditions(nside=8, mjd=tt.mjd)
+        self.assertEqual(bandsched(conditions), ["z", "y"])
+        tt = Time("2025-08-07T20:00:00")
+        conditions = Conditions(nside=8, mjd=tt.mjd)
+        conditions.moon_phase_sunset = 25
+        self.assertEqual(bandsched(conditions), ["u", "g", "r", "i", "z"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summit schedules filter changes on particular dates, which prenight simulations need to match (and more detailed upcoming-weeks-ish simulations such as for SV survey) need to incorporate too, to help provide feedback on filter changes. 

If we want to simulate visits from the start of the survey, to check that predictions match actual outputs, this will also be necessary to synchronize filter changes (so should keep historical records too). 

This also gives us a way to provide limited filter set options during periods when a filter may be missing. 