### PR TITLE
Make night be calculated rather than set by user

### DIFF
--- a/rubin_scheduler/scheduler/detailers/dither_detailer.py
+++ b/rubin_scheduler/scheduler/detailers/dither_detailer.py
@@ -95,7 +95,6 @@ class DitherDetailer(BaseDetailer):
             return obs_array
         # Generate offsets in RA and Dec
         offsets = self._generate_offsets(len(obs_array), conditions.night)
-
         new_ra, new_dec = gnomonic_project_tosky(
             offsets[:, 0], offsets[:, 1], obs_array["RA"], obs_array["dec"]
         )

--- a/rubin_scheduler/scheduler/detailers/dither_detailer.py
+++ b/rubin_scheduler/scheduler/detailers/dither_detailer.py
@@ -49,7 +49,7 @@ class DitherDetailer(BaseDetailer):
     def __init__(self, max_dither=0.7, seed=42, per_night=True, nnights=7305):
         self.survey_features = {"n_in_night": NObsCount(per_night=True)}
 
-        self.current_night = -1
+        self.current_night = -np.inf
         self.max_dither = np.radians(max_dither)
         self.per_night = per_night
         self.rng = np.random.default_rng(seed)
@@ -65,7 +65,6 @@ class DitherDetailer(BaseDetailer):
 
         self.offset_ra = None
         self.offset_dec = None
-        self.current_night = -1
 
     def _generate_offsets(self, n_offsets, night):
 
@@ -246,7 +245,7 @@ class EuclidDitherDetailer(BaseDetailer):
         self.bearing_atob = bearing(self.ra_a, self.dec_a, self.ra_b, self.dec_b)
         self.bearing_btoa = bearing(self.ra_b, self.dec_b, self.ra_a, self.dec_a)
 
-        self.current_night = -1
+        self.current_night = -np.inf
 
         self.per_night = per_night
         self.shifted_ra_a = None
@@ -430,7 +429,7 @@ class CameraRotDetailer(BaseDetailer):
             warnings.warn("dither=False deprecated, swapping to dither='all'", FutureWarning)
             dither = "all"
 
-        self.current_night = -1
+        self.current_night = -np.inf
         self.max_rot = np.radians(max_rot)
         self.min_rot = np.radians(min_rot)
         self.range = self.max_rot - self.min_rot

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -517,6 +517,15 @@ class Conditions:
     def calc_night(self):
         self._night = np.floor(self.mjd - self.survey_start_mjd + self.mjd_night_offset).astype(int)
 
+    @night.setter
+    def night(self, val):
+        msg = (
+            "Attribute 'night' no longer to be set by users. "
+            "Set survey_start_mjd on init and mjd so Conditions"
+            "can compute value for 'night'."
+        )
+        warnings.DeprecationWarning(msg)
+
     @property
     def m5_depth(self):
         if self._m5_depth is None:

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -64,7 +64,6 @@ class Conditions:
         exptime=30.0,
         mjd=None,
         survey_start_mjd=SURVEY_START_MJD,
-        mjd_night_offset=0.5,
     ):
         """
         Attributes (Set on init)
@@ -80,12 +79,9 @@ class Conditions:
         dec : `np.ndarray`, (N,)
             A healpix array with the Dec of each healpixel center (radians).
             Automatically generated.
-        mjd_night_offset : `float`
-            Value to use when computing night of the survey.
-            Should be such that floor(mjd - mjd_night_offset) will
-            not change during the night. Default 0.5 (days).
         survey_start_mjd : `float`
-            The starting MJD of the survey.
+            The starting MJD of the survey. Should be durring the day
+            before the first night of observing.
 
         Attributes (to be set by user/telemetry stream/scheduler)
         -------------------------------------------
@@ -244,7 +240,6 @@ class Conditions:
         """
         self.nside = nside
         self.survey_start_mjd = survey_start_mjd
-        self.mjd_night_offset = mjd_night_offset
 
         # The RA, Dec grid we are using
         hpids = np.arange(hp.nside2npix(self.nside))
@@ -515,10 +510,7 @@ class Conditions:
         return np.max(self._night)
 
     def calc_night(self):
-        self._night = (
-            np.floor(self.mjd - self.mjd_night_offset)
-            - np.floor(self.survey_start_mjd - self.mjd_night_offset)
-        ).astype(int)
+        self._night = np.floor(self.mjd - self.survey_start_mjd).astype(int)
 
     @night.setter
     def night(self, val):

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -515,7 +515,10 @@ class Conditions:
         return np.max(self._night)
 
     def calc_night(self):
-        self._night = np.floor(self.mjd - self.survey_start_mjd + self.mjd_night_offset).astype(int)
+        self._night = (
+            np.floor(self.mjd - self.mjd_night_offset)
+            - np.floor(self.survey_start_mjd - self.mjd_night_offset)
+        ).astype(int)
 
     @night.setter
     def night(self, val):

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -57,7 +57,8 @@ class ModelObservatory:
     mjd_start : `float`, optional
         The MJD of the start of the survey.
         This must be set to start of whole survey, for tracking
-        purposes.  Default None uses `survey_start_mjd()`.
+        purposes. Should be during the day so night will be
+        computed properly.
     alt_min : `float`, optional
         The minimum altitude to compute models at (degrees).
     lax_dome : `bool`, optional
@@ -175,7 +176,6 @@ class ModelObservatory:
         telescope="rubin",
         cloud_maps=None,
         resolve_rotskypos=True,
-        mjd_night_offset=0.5,
     ):
         self.nside = nside
         self.resolve_rotskypos = resolve_rotskypos
@@ -183,8 +183,6 @@ class ModelObservatory:
         # Set the time now - mjd
         # and the time of the survey start
         self.mjd_start = mjd_start
-
-        self.mjd_night_offset = mjd_night_offset
 
         if mjd is None:
             mjd = mjd_start
@@ -510,9 +508,7 @@ class ModelObservatory:
     def mjd(self, value):
         self._mjd = value
         self.almanac_indx = self.almanac.mjd_indx(value)
-        self.night = (
-            np.floor(self.mjd - self.mjd_night_offset) - np.floor(self.mjd_start - self.mjd_night_offset)
-        ).astype(int)
+        self.night = np.floor(self.mjd - self.mjd_start).astype(int)
 
     def observation_add_data(self, observation):
         """

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -175,6 +175,7 @@ class ModelObservatory:
         telescope="rubin",
         cloud_maps=None,
         resolve_rotskypos=True,
+        mjd_night_offset=0.5,
     ):
         self.nside = nside
         self.resolve_rotskypos = resolve_rotskypos
@@ -182,6 +183,8 @@ class ModelObservatory:
         # Set the time now - mjd
         # and the time of the survey start
         self.mjd_start = mjd_start
+
+        self.mjd_night_offset = mjd_night_offset
 
         if mjd is None:
             mjd = mjd_start
@@ -379,7 +382,6 @@ class ModelObservatory:
             mjd=self.mjd,
         )
 
-        self.conditions.night = int(self.night)
         # Current time as astropy time
         current_time = Time(self.mjd, format="mjd")
 
@@ -508,7 +510,7 @@ class ModelObservatory:
     def mjd(self, value):
         self._mjd = value
         self.almanac_indx = self.almanac.mjd_indx(value)
-        self.night = np.max(self.almanac.sunsets["night"][self.almanac_indx])
+        self.night = np.floor(self.mjd - self.mjd_start + self.mjd_night_offset).astype(int)
 
     def observation_add_data(self, observation):
         """

--- a/rubin_scheduler/scheduler/model_observatory/model_observatory.py
+++ b/rubin_scheduler/scheduler/model_observatory/model_observatory.py
@@ -510,7 +510,9 @@ class ModelObservatory:
     def mjd(self, value):
         self._mjd = value
         self.almanac_indx = self.almanac.mjd_indx(value)
-        self.night = np.floor(self.mjd - self.mjd_start + self.mjd_night_offset).astype(int)
+        self.night = (
+            np.floor(self.mjd - self.mjd_night_offset) - np.floor(self.mjd_start - self.mjd_night_offset)
+        ).astype(int)
 
     def observation_add_data(self, observation):
         """

--- a/rubin_scheduler/scheduler/schedulers/core_scheduler.py
+++ b/rubin_scheduler/scheduler/schedulers/core_scheduler.py
@@ -51,10 +51,6 @@ class CoreScheduler:
         will do no mapping for missing "filter" values.
     survey_start_mjd : `float`
             The starting MJD of the survey.
-    mjd_night_offset : `float`
-        Value to use when computing night of the survey.
-        Should be such that floor(mjd - mjd_night_offset) will
-        not change during the night. Default 0.5 (days).
     """
 
     def __init__(
@@ -68,11 +64,9 @@ class CoreScheduler:
         target_id_counter=0,
         band_to_filter=None,
         survey_start_mjd=SURVEY_START_MJD,
-        mjd_night_offset=0.5,
     ):
         self.keep_rewards = keep_rewards
         self.survey_start_mjd = survey_start_mjd
-        self.mjd_night_offset = mjd_night_offset
         # Use integer ns just to be sure there are no rounding issues.
         self.mjd_perf_counter_offset = np.int64(Time.now().mjd * 86400000000000) - time.perf_counter_ns()
 
@@ -238,7 +232,6 @@ class CoreScheduler:
 
         # Use our own def of survey start
         self.conditions.survey_start_mjd = self.survey_start_mjd
-        self.conditions.mjd_night_offset = self.mjd_night_offset
 
         # put the local queue in the conditions
         self.conditions.queue = self.queue

--- a/rubin_scheduler/utils/constants.py
+++ b/rubin_scheduler/utils/constants.py
@@ -5,7 +5,7 @@ import warnings
 from astropy.time import Time
 
 DEFAULT_NSIDE = 32  # HEALpix nside, ~1.83 degree resolution
-SURVEY_START_MJD = Time("2025-11-01T12:00:00").mjd
+SURVEY_START_MJD = Time("2025-11-01T12:00:00").mjd  # Should be during the day before first observation
 
 
 def survey_start_mjd():

--- a/tests/scheduler/test_detailers.py
+++ b/tests/scheduler/test_detailers.py
@@ -155,12 +155,11 @@ class TestDetailers(unittest.TestCase):
 
         det = detailers.RandomBandDetailer(bands="iz")
 
-        conditions = Conditions()
-        conditions.night = 3
+        conditions = Conditions(mjd=3, survey_start_mjd=0)
         conditions.mounted_bands = ["i", "z"]
 
         out_obs = det(obs, conditions)
-        assert (out_obs["band"] == "i") | (out_obs["filter"] == "z")
+        assert (out_obs["band"] == "i") | (out_obs["band"] == "z")
 
         # Check that we fall back properly
         conditions.mounted_bands = ["r", "g", "u", "y"]

--- a/tests/scheduler/test_utils.py
+++ b/tests/scheduler/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import unittest
 
 import healpy as hp
@@ -22,7 +23,7 @@ from rubin_scheduler.utils import SURVEY_START_MJD
 
 class TestUtils(unittest.TestCase):
     def tearDownClass():
-        os.remove("temp.sqlite")
+        pathlib.Path("temp.sqlite").unlink(missing_ok=True)
 
     @unittest.skipUnless(
         os.path.isfile(os.path.join(get_data_dir(), "scheduler/dust_maps/dust_nside_32.npz")),
@@ -39,7 +40,8 @@ class TestUtils(unittest.TestCase):
         "Test data not available.",
     )
     def test_start_of_night_example(self):
-        """Test the example scheduler starting at the beginnig of a night."""
+        """Test example scheduler and sim_runner having mis-matched
+        start dates."""
         mjd_start = SURVEY_START_MJD
         scheduler = example_scheduler(mjd_start=mjd_start)
         observatory, scheduler, observations = run_sched(


### PR DESCRIPTION
Have the `Conditions` object compute the `night` value rather than have it manually set. The `CoreScheduler` will override `conditions.survey_start_mjd` value with it's own.