### PR TITLE
ticktes/SP-2539: Fix loading of tokens from files for consdb query

### DIFF
--- a/rubin_scheduler/utils/consdb.py
+++ b/rubin_scheduler/utils/consdb.py
@@ -104,6 +104,9 @@ def query_consdb(
         url = _guess_consdb_endpoint()
     assert url is not None
 
+    if token_file is None:
+        token_file = os.environ.get('ACCESS_TOKEN_FILE', None)
+
     auth = _get_auth(token_file)
     params = {"query": query}
 
@@ -346,12 +349,12 @@ class ConsDBVisits(ABC):
             """
 
         visit_columns = (
-            query_consdb(columns_query(f"visit{self.num_exposures}", self.instrument), url=self.url)
+            query_consdb(columns_query(f"visit{self.num_exposures}", self.instrument), url=self.url, token_file=self.token_file)
             .loc[:, "column_name"]
             .values
         )
         ql_columns = (
-            query_consdb(columns_query(f"visit{self.num_exposures}_quicklook", self.instrument), url=self.url)
+            query_consdb(columns_query(f"visit{self.num_exposures}_quicklook", self.instrument), url=self.url, token_file=self.token_file)
             .loc[:, "column_name"]
             .values
         )

--- a/rubin_scheduler/utils/consdb.py
+++ b/rubin_scheduler/utils/consdb.py
@@ -105,7 +105,7 @@ def query_consdb(
     assert url is not None
 
     if token_file is None:
-        token_file = os.environ.get('ACCESS_TOKEN_FILE', None)
+        token_file = os.environ.get("ACCESS_TOKEN_FILE", None)
 
     auth = _get_auth(token_file)
     params = {"query": query}
@@ -349,12 +349,20 @@ class ConsDBVisits(ABC):
             """
 
         visit_columns = (
-            query_consdb(columns_query(f"visit{self.num_exposures}", self.instrument), url=self.url, token_file=self.token_file)
+            query_consdb(
+                columns_query(f"visit{self.num_exposures}", self.instrument),
+                url=self.url,
+                token_file=self.token_file,
+            )
             .loc[:, "column_name"]
             .values
         )
         ql_columns = (
-            query_consdb(columns_query(f"visit{self.num_exposures}_quicklook", self.instrument), url=self.url, token_file=self.token_file)
+            query_consdb(
+                columns_query(f"visit{self.num_exposures}_quicklook", self.instrument),
+                url=self.url,
+                token_file=self.token_file,
+            )
             .loc[:, "column_name"]
             .values
         )


### PR DESCRIPTION
This will be obsoleted by SP-2442 and whatever follows it, but is a quick fix in the mean time.
There will be a corresponding pull request on schedview_notebooks shortly.