### PR TITLE
set default survey start to be in the day

### DIFF
--- a/rubin_scheduler/utils/constants.py
+++ b/rubin_scheduler/utils/constants.py
@@ -2,8 +2,10 @@ __all__ = ("DEFAULT_NSIDE", "SURVEY_START_MJD", "survey_start_mjd")
 
 import warnings
 
+from astropy.time import Time
+
 DEFAULT_NSIDE = 32  # HEALpix nside, ~1.83 degree resolution
-SURVEY_START_MJD = 60980.0  # 60980 = Nov 1, 2025
+SURVEY_START_MJD = Time("2025-11-01T12:00:00").mjd
 
 
 def survey_start_mjd():

--- a/tests/scheduler/test_baseline.py
+++ b/tests/scheduler/test_baseline.py
@@ -18,9 +18,11 @@ class TestExample(unittest.TestCase):
         """Try out the example scheduler."""
         mjd_start = utils.SURVEY_START_MJD
         nside = 32
-        survey_length = 2.0  # days
+        survey_length = 4.0  # days
         scheduler = example_scheduler(nside=nside, mjd_start=mjd_start)
-        observatory = ModelObservatory(nside=nside, mjd_start=mjd_start)
+        observatory = ModelObservatory(
+            nside=nside, mjd_start=mjd_start, cloud_data="ideal", downtimes="ideal"
+        )
         observatory, scheduler, observations = sim_runner(
             observatory, scheduler, sim_duration=survey_length, filename=None
         )

--- a/tests/utils/test_constants.py
+++ b/tests/utils/test_constants.py
@@ -1,0 +1,31 @@
+import unittest
+
+import healpy as hp
+from astropy.coordinates import AltAz, EarthLocation, get_sun
+from astropy.time import Time
+
+import rubin_scheduler.utils as utils
+
+
+class Constantsests(unittest.TestCase):
+
+    def test_survey_start(self):
+        ss_mjd = utils.SURVEY_START_MJD
+        ss_time = Time(ss_mjd, format="mjd")
+
+        # Demand that the default start date be during the day
+        site = utils.Site("LSST")
+        location = EarthLocation(lat=site.latitude, lon=site.longitude, height=site.height)
+        sun = get_sun(ss_time)
+        aa = AltAz(location=location, obstime=ss_time)
+        sun_aa = sun.transform_to(aa)
+        assert sun_aa.alt > 0
+
+    def test_nside(self):
+        nside = utils.DEFAULT_NSIDE
+        npix = hp.nside2npix(nside)
+        assert npix > 0
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Roll survey start back 0.5 days to ensure sims don't start in the middle of the night.  

Add unit test to make sure SURVEY_START_MJD is during the day for the observatory.