### PR TITLE
tickets/SP-2611: make -wrap_180 work for arrays with 1 element

### DIFF
--- a/rubin_scheduler/utils/rotskypos.py
+++ b/rubin_scheduler/utils/rotskypos.py
@@ -108,8 +108,10 @@ def _wrap_180(in_angle):
     in_angle : `float`
         Input angle in radians.
     """
+    # angle = np.atan2(np.sin(in_angle), np.cos(in_angle))
+    # would be simpler, but maybe slower?
     angle = in_angle % (2.0 * np.pi)
-    if np.size(angle) == 1:
+    if np.isscalar(angle):
         if angle > np.pi:
             result = angle - 2.0 * np.pi
             return result


### PR DESCRIPTION
On a `np.array` or `pd.Series` with exactly one element, `np.size(angle) == 1` but `if angle > np.pi` fails.