### PR TITLE
roll band detailer

### DIFF
--- a/rubin_scheduler/scheduler/detailers/detailer.py
+++ b/rubin_scheduler/scheduler/detailers/detailer.py
@@ -25,6 +25,7 @@ __all__ = (
     "LabelRegionDetailer",
     "LabelDDFDetailer",
     "LabelRegionsAndDDFs",
+    "RollBandMatchDetailer",
 )
 
 import copy
@@ -148,6 +149,20 @@ class TrackingInfoDetailer(BaseDetailer):
                 | (observation_array[key] == "None")
             )[0]
             observation_array[key][indx] = getattr(self, key)
+
+        return observation_array
+
+
+class RollBandMatchDetailer(BaseDetailer):
+    """Roll the order of visits to eliminate a filter change."""
+
+    def __call__(self, observation_array, conditions):
+
+        bm_index = np.where(observation_array["band"] == conditions.current_band)[0]
+        if np.size(bm_index) > 0:
+            indx = np.arange(observation_array.size)
+            indx = np.roll(indx, -np.min(bm_index))
+            observation_array = observation_array[indx]
 
         return observation_array
 

--- a/tests/scheduler/test_detailers.py
+++ b/tests/scheduler/test_detailers.py
@@ -532,6 +532,30 @@ class TestDetailers(unittest.TestCase):
 
         assert n3 > 0
 
+    def test_rollband(self):
+
+        orig_order = np.array(["u", "g", "r"])
+
+        observation_array = ObservationArray(n=3)
+        observation_array["band"] = ["u", "g", "r"]
+
+        # Test where no change should happen
+        detailer = detailers.RollBandMatchDetailer()
+        conditions = Conditions()
+        conditions.current_band = "u"
+        o1 = detailer(observation_array, conditions)
+        for bn, ob in zip(orig_order, o1["band"]):
+            assert bn == ob
+
+        # Test where things should roll
+        conditions.current_band = "r"
+        o2 = detailer(observation_array, conditions)
+
+        assert o2["band"][0] == "r"
+
+        for bn in orig_order:
+            assert bn in o2["band"]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Handy detailer for Roman surveys that have a set sequence of visits, but can roll the order to potentially avoid a filter change.