### PR TITLE
SP-3063: split wind basis function to mask and regular bf

### DIFF
--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -1396,18 +1396,35 @@ class WindPressureBasisFunction(BaseBasisFunction):
 
     Parameters
     ----------
+    wind_speed_maximum : `float`, optional
+        Wind speed to mark regions as unobservable (in m/s).
+    wind_speed_minimum : `float`, optional
+        If wind speed blow this level, return no effective reward
+        map. Default 0 (m/s).
     nside : `int`, optional
         The nside for the basis function. Default None uses
         `set_default_nside()`.
     """
 
-    def __init__(self, nside=DEFAULT_NSIDE):
+    def __init__(self, wind_speed_maximum=20.0, wind_speed_minimum=0.0, nside=DEFAULT_NSIDE):
+
+        if wind_speed_maximum < wind_speed_minimum:
+            raise ValueError(
+                "wind_speed_maximum of %f m/s is less than wind_speed_minimum value of %f m/s."
+                % (wind_speed_maximum, wind_speed_minimum)
+            )
         super().__init__(nside=nside)
+        self.wind_speed_maximum = wind_speed_maximum
+        self.wind_speed_minimum = wind_speed_minimum
 
     def _calc_value(self, conditions, indx=None):
         reward_map = np.zeros(hp.nside2npix(self.nside))
 
-        if conditions.wind_speed is None or conditions.wind_direction is None:
+        if (
+            conditions.wind_speed is None
+            or conditions.wind_direction is None
+            or conditions.wind_speed < self.wind_speed_minimum
+        ):
             return reward_map
 
         reward_map -= conditions.wind_pressure**2.0

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -1399,7 +1399,7 @@ class WindPressureBasisFunction(BaseBasisFunction):
     wind_speed_maximum : `float`, optional
         Wind speed to mark regions as unobservable (in m/s).
     wind_speed_minimum : `float`, optional
-        If wind speed blow this level, return no effective reward
+        If wind speed below this level, return no effective reward
         map. Default 0 (m/s).
     nside : `int`, optional
         The nside for the basis function. Default None uses

--- a/rubin_scheduler/scheduler/basis_functions/basis_functions.py
+++ b/rubin_scheduler/scheduler/basis_functions/basis_functions.py
@@ -33,6 +33,7 @@ __all__ = (
     "FilterDistBasisFunction",
     "RewardRisingBasisFunction",
     "send_unused_deprecation_warning",
+    "WindPressureBasisFunction",
 )
 
 import warnings
@@ -1367,6 +1368,8 @@ class AvoidDirectWind(BaseBasisFunction):
     """
 
     def __init__(self, wind_speed_maximum=20.0, nside=DEFAULT_NSIDE):
+        message = "AvoidDirectWind deprecated, use MaskDirectWindBasisFunction and WindPressureBasisFunction."
+        warnings.warn(message, FutureWarning)
         super().__init__(nside=nside)
 
         self.wind_speed_maximum = wind_speed_maximum
@@ -1384,6 +1387,30 @@ class AvoidDirectWind(BaseBasisFunction):
         mask = wind_pressure > self.wind_speed_maximum
 
         reward_map[mask] = np.nan
+
+        return reward_map
+
+
+class WindPressureBasisFunction(BaseBasisFunction):
+    """Have negaitive reward for wind pressure squared.
+
+    Parameters
+    ----------
+    nside : `int`, optional
+        The nside for the basis function. Default None uses
+        `set_default_nside()`.
+    """
+
+    def __init__(self, nside=DEFAULT_NSIDE):
+        super().__init__(nside=nside)
+
+    def _calc_value(self, conditions, indx=None):
+        reward_map = np.zeros(hp.nside2npix(self.nside))
+
+        if conditions.wind_speed is None or conditions.wind_direction is None:
+            return reward_map
+
+        reward_map -= conditions.wind_pressure**2.0
 
         return reward_map
 

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -14,6 +14,7 @@ __all__ = (
     "MaskAfterNObsBasisFunction",
     "MaskPoorSeeing",
     "MaskAfterNObsSeeingBasisFunction",
+    "MaskDirectWindBasisFunction",
 )
 
 import warnings
@@ -25,6 +26,35 @@ import rubin_scheduler.scheduler.features as features
 from rubin_scheduler.scheduler.basis_functions import BaseBasisFunction
 from rubin_scheduler.scheduler.utils import CurrentAreaMap, HpInLsstFov, IntRounded
 from rubin_scheduler.utils import DEFAULT_NSIDE, SURVEY_START_MJD, _angular_separation, _hp_grow_mask
+
+
+class MaskDirectWindBasisFunction(BaseBasisFunction):
+    """Mask area looking into the wind
+
+    Parameters
+    ----------
+    wind_speed_maximum : `float`, optional
+        Wind speed to mark regions as unobservable (in m/s).
+    nside : `int`, optional
+        The nside for the basis function. Default None uses
+        `set_default_nside()`.
+    """
+
+    def __init__(self, wind_speed_maximum=20.0, nside=DEFAULT_NSIDE):
+        super().__init__(nside=nside)
+
+        self.wind_speed_maximum = wind_speed_maximum
+
+    def _calc_value(self, conditions, indx=None):
+        reward_map = np.zeros(hp.nside2npix(self.nside))
+
+        if conditions.wind_speed is None or conditions.wind_direction is None:
+            return reward_map
+
+        mask = conditions.wind_pressure > self.wind_speed_maximum
+        reward_map[mask] = np.nan
+
+        return reward_map
 
 
 class MaskPoorSeeing(BaseBasisFunction):

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -29,7 +29,7 @@ from rubin_scheduler.utils import DEFAULT_NSIDE, SURVEY_START_MJD, _angular_sepa
 
 
 class MaskDirectWindBasisFunction(BaseBasisFunction):
-    """Mask area looking into the wind
+    """Mask azimuth where effective wind speed exceeds the maximum.
 
     Parameters
     ----------

--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -231,6 +231,8 @@ class Conditions:
             for each healpixel (radians)
         night : `int`
             The current night number (days).
+        wind_pressure : `np.ndarray`
+            The pressure from the wind.
 
         Attributes (set by the scheduler)
         -------------------------------
@@ -284,6 +286,7 @@ class Conditions:
 
         self.wind_speed = None
         self.wind_direction = None
+        self._wind_pressure = None
 
         # Upcoming scheduled observations
         self.scheduled_observations = np.array([], dtype=float)
@@ -543,6 +546,15 @@ class Conditions:
 
     def calc_solar_elongation(self):
         self._solar_elongation = _angular_separation(self.ra, self.dec, self.sun_ra, self.sun_dec)
+
+    @property
+    def wind_pressure(self):
+        if self._wind_pressure is None:
+            self.calc_wind_pressure()
+        return self._wind_pressure
+
+    def calc_wind_pressure(self):
+        self._wind_pressure = self.wind_speed * np.cos(self.az - self.wind_direction)
 
     @property
     def solar_elongation(self):

--- a/tests/scheduler/test_basisfuncs.py
+++ b/tests/scheduler/test_basisfuncs.py
@@ -33,7 +33,6 @@ class TestBasis(unittest.TestCase):
             basis_functions.NearSunHighAirmassBasisFunction,
             basis_functions.EclipticBasisFunction,
             basis_functions.NGoodSeeingBasisFunction,
-            basis_functions.AvoidDirectWind,
             basis_functions.BandDistBasisFunction,
             basis_functions.RewardRisingBasisFunction,
             basis_functions.BandLoadedBasisFunction,
@@ -66,6 +65,8 @@ class TestBasis(unittest.TestCase):
             basis_functions.NInNightMaskBasisFunction,
             basis_functions.OnlyBeforeNightBasisFunction,
             basis_functions.MaskAfterNObsBasisFunction,
+            basis_functions.WindPressureBasisFunction,
+            basis_functions.MaskDirectWindBasisFunction,
         ]
 
         obs = ObservationArray()
@@ -493,6 +494,7 @@ class TestBasis(unittest.TestCase):
             basis_functions.StrictFilterBasisFunction,
             basis_functions.FilterChangeBasisFunction,
             basis_functions.FilterDistBasisFunction,
+            basis_functions.AvoidDirectWind,
         ]
         for dep_bf in deprecated_basis_functions:
             with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Split `AvoidDirectWind` into a wind pressure masking basis function and a wind pressure preference basis function. Refactored to put the calculation of wind pressure in the `Conditions` object.
