### PR TITLE
SP-3091: address queue manager masking more than required pixels; extend capabilities for current config (for templates and dynapairs)

### DIFF
--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -120,8 +120,7 @@ class MaskAfterNObsSeeingBasisFunction(BaseBasisFunction):
             self.survey_features["nobs"] = features.NObservations(
                 nside=nside,
                 bandname=bandname,
-                mjd_start=mjd_start,
-                seeing_fwhm_max=seeing_fwhm_max,
+                seeing_limit=seeing_fwhm_max,
             )
         self.result = np.zeros(hp.nside2npix(self.nside), dtype=float)
 

--- a/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
+++ b/rubin_scheduler/scheduler/basis_functions/mask_basis_funcs.py
@@ -84,8 +84,7 @@ class MaskPoorSeeing(BaseBasisFunction):
 
 
 class MaskAfterNObsSeeingBasisFunction(BaseBasisFunction):
-    """Mask after a HEALpix has been observed N times. In a
-    season.
+    """Mask after a HEALpix has been observed N times.
 
     Parameters
     ----------
@@ -95,6 +94,8 @@ class MaskAfterNObsSeeingBasisFunction(BaseBasisFunction):
         The bandname. Default None uses all bands.
     seeing_fwhm_max : `float`
         The seeing limit to use when counting observations (arcsec).
+    reset_per_season : `bool`
+        Should the mask reset each season. Default True.
     """
 
     def __init__(
@@ -103,16 +104,25 @@ class MaskAfterNObsSeeingBasisFunction(BaseBasisFunction):
         nside=DEFAULT_NSIDE,
         bandname=None,
         seeing_fwhm_max=1.3,
+        reset_per_season=True,
         mjd_start=SURVEY_START_MJD,
     ):
         super().__init__(nside=nside)
         self.n_max = n_max
-        self.survey_features["nobs"] = features.NObservationsCurrentSeason(
-            nside=nside,
-            bandname=bandname,
-            mjd_start=mjd_start,
-            seeing_fwhm_max=seeing_fwhm_max,
-        )
+        if reset_per_season:
+            self.survey_features["nobs"] = features.NObservationsCurrentSeason(
+                nside=nside,
+                bandname=bandname,
+                mjd_start=mjd_start,
+                seeing_fwhm_max=seeing_fwhm_max,
+            )
+        else:
+            self.survey_features["nobs"] = features.NObservations(
+                nside=nside,
+                bandname=bandname,
+                mjd_start=mjd_start,
+                seeing_fwhm_max=seeing_fwhm_max,
+            )
         self.result = np.zeros(hp.nside2npix(self.nside), dtype=float)
 
     def _calc_value(self, conditions, indx=None):

--- a/rubin_scheduler/scheduler/schedulers/core_scheduler.py
+++ b/rubin_scheduler/scheduler/schedulers/core_scheduler.py
@@ -346,8 +346,10 @@ class CoreScheduler:
         else:
             result = self.queue_manager.request_observation(self.conditions, whole_queue=whole_queue)
 
-            # Queue manager may have killed everything and we need to refill
+            # Queue manager may have killed everything and we need to
+            # flush and refill
             if np.size(result) == 0:
+                self.queue_manager.flush_queue()
                 self._fill_queue()
                 result = self.queue_manager.request_observation(self.conditions, whole_queue=whole_queue)
                 if np.size(result) == 0:

--- a/rubin_scheduler/scheduler/schedulers/queue_manager.py
+++ b/rubin_scheduler/scheduler/schedulers/queue_manager.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from rubin_scheduler.scheduler.detailers import RotspUpdateDetailer
 from rubin_scheduler.scheduler.utils import IntRounded, ObservationArray
+from rubin_scheduler.utils import _ra_dec2_hpid
 
 
 class BaseQueueManager:
@@ -134,12 +135,17 @@ class BaseQueueManager:
         # need to interpolate to the actual positions we want.
         # now to interpolate to the reward positions
         if np.size(reward) > 1:
-            reward_interp = hp.get_interp_val(
-                reward,
-                np.degrees(self.desired_observations_array["RA"][valid]),
-                np.degrees(self.desired_observations_array["dec"][valid]),
-                lonlat=True,
+            # hp.get_interp_val uses 4 nearest neighbors, so that can
+            # go nan if a farther helpix is masked. This uses the
+            # HEALpix the RA,dec falls in. Technically should probably be
+            # the nearest neighbor HEALpix center.
+            nside = hp.npix2nside(reward.size)
+            hpids = _ra_dec2_hpid(
+                nside,
+                self.desired_observations_array["RA"][valid],
+                self.desired_observations_array["dec"][valid],
             )
+            reward_interp = reward[hpids]
             sub_valid_reward = np.isfinite(reward_interp)
             valid = np.ravel(valid[sub_valid_reward])
 

--- a/rubin_scheduler/scheduler/surveys/surveys.py
+++ b/rubin_scheduler/scheduler/surveys/surveys.py
@@ -219,7 +219,7 @@ class BlobSurvey(GreedySurvey):
         filtername1=None,
         filtername2=None,
         filter_change_approx=None,
-        note_block_size=True,
+        note_block_size=False,
     ):
         if filtername1 is not None:
             warnings.warn("filtername1 deprecated in favor of bandname1", FutureWarning)

--- a/rubin_scheduler/scheduler/surveys/surveys.py
+++ b/rubin_scheduler/scheduler/surveys/surveys.py
@@ -192,7 +192,7 @@ class BlobSurvey(GreedySurvey):
         nexp=2,
         nexp_dict=None,
         ideal_pair_time=22.0,
-        max_pair_time=40.0,
+        max_pair_time=None,
         flush_time=30.0,
         smoothing_kernel=None,
         nside=DEFAULT_NSIDE,
@@ -390,8 +390,9 @@ class BlobSurvey(GreedySurvey):
             possible_times = available_time / np.arange(1, 4)
             diff = np.abs(self.ideal_pair_time - possible_times)
             best_block_time = np.max(possible_times[np.where(diff == np.min(diff))])
-            if best_block_time > self.max_pair_time:
-                best_block_time = self.max_pair_time
+            if self.max_pair_time is not None:
+                if best_block_time > self.max_pair_time:
+                    best_block_time = self.max_pair_time
             self.nvisit_block = int(
                 np.floor(
                     best_block_time

--- a/rubin_scheduler/scheduler/surveys/surveys.py
+++ b/rubin_scheduler/scheduler/surveys/surveys.py
@@ -136,6 +136,8 @@ class BlobSurvey(GreedySurvey):
     ideal_pair_time : `float`
         The ideal time gap wanted between observations to the same
         pointing (minutes)
+    max_pair_time : `float`
+        Maximum pair time to allow. Default 40 (minutes)
     flush_time : `float`
         The time past the final expected exposure to flush the queue.
         Keeps observations from lingering past when they should be
@@ -190,6 +192,7 @@ class BlobSurvey(GreedySurvey):
         nexp=2,
         nexp_dict=None,
         ideal_pair_time=22.0,
+        max_pair_time=40.0,
         flush_time=30.0,
         smoothing_kernel=None,
         nside=DEFAULT_NSIDE,
@@ -243,6 +246,7 @@ class BlobSurvey(GreedySurvey):
         self.bandname2 = bandname2
 
         self.ideal_pair_time = ideal_pair_time
+        self.max_pair_time = max_pair_time
 
         if survey_name is None:
             self._generate_survey_name()
@@ -381,11 +385,13 @@ class BlobSurvey(GreedySurvey):
             # Now we can stretch or contract the block size to
             # allocate the
             # remainder time until twilight starts
-            # We can take the remaining time and try to do 1,2,
-            # or 3 blocks.
+            # We can take the remaining time and try 1-3 blocks
+            # XXX--magic number
             possible_times = available_time / np.arange(1, 4)
             diff = np.abs(self.ideal_pair_time - possible_times)
             best_block_time = np.max(possible_times[np.where(diff == np.min(diff))])
+            if best_block_time > self.max_pair_time:
+                best_block_time = self.max_pair_time
             self.nvisit_block = int(
                 np.floor(
                     best_block_time
@@ -525,12 +531,14 @@ class BlobSurvey(GreedySurvey):
                 observations["nexp"] = self.nexp_dict[bandname]
             observations["exptime"] = self.exptime
             observations["scheduler_note"] = self.scheduler_note
-            if self.note_block_size:
-                observations["scheduler_note"] += ", block_size %i" % self.nvisit_block
             observations["flush_by_mjd"] = flush_time
             all_observations.append(observations)
             track_n_in_nvisit.append(np.arange(observations.size))
         observations = np.concatenate(all_observations)
+        if self.note_block_size:
+            observations["scheduler_note"] = np.char.add(
+                observations["scheduler_note"], ", bs %i" % observations.size
+            )
 
         if self.n_visits > 1:
             track_n_in_nvisit = np.concatenate(track_n_in_nvisit)

--- a/rubin_scheduler/scheduler/surveys/surveys.py
+++ b/rubin_scheduler/scheduler/surveys/surveys.py
@@ -164,6 +164,9 @@ class BlobSurvey(GreedySurvey):
         String added to observation_reason field. Default value of
         'generate_obs_reason' will result in auto-generated string
         like 'pairs_{bandname1}{bandname2}_{ideal_pair_time}'.
+    note_block_size : `bool`
+        Add to the scheduler note what the final block size was for
+        the blob. Default True.
 
     Notes
     -----
@@ -213,6 +216,7 @@ class BlobSurvey(GreedySurvey):
         filtername1=None,
         filtername2=None,
         filter_change_approx=None,
+        note_block_size=True,
     ):
         if filtername1 is not None:
             warnings.warn("filtername1 deprecated in favor of bandname1", FutureWarning)
@@ -279,6 +283,7 @@ class BlobSurvey(GreedySurvey):
         self.in_twilight = in_twilight
         self.grow_blob = grow_blob
         self.max_radius_peak = np.radians(max_radius_peak)
+        self.note_block_size = note_block_size
 
         if self.twilight_scale & self.in_twilight:
             warnings.warn("Both twilight_scale and in_twilight are set to True. That is probably wrong.")
@@ -520,6 +525,8 @@ class BlobSurvey(GreedySurvey):
                 observations["nexp"] = self.nexp_dict[bandname]
             observations["exptime"] = self.exptime
             observations["scheduler_note"] = self.scheduler_note
+            if self.note_block_size:
+                observations["scheduler_note"] += ", block_size %i" % self.nvisit_block
             observations["flush_by_mjd"] = flush_time
             all_observations.append(observations)
             track_n_in_nvisit.append(np.arange(observations.size))

--- a/rubin_scheduler/utils/healpy_utils.py
+++ b/rubin_scheduler/utils/healpy_utils.py
@@ -9,6 +9,7 @@ __all__ = (
     "hp_grow_argsort",
     "_hp_grow_mask",
     "match_hp_resolution",
+    "ra_dec_nearest_interp",
 )
 
 import warnings
@@ -18,6 +19,38 @@ import healpy as hp
 import numpy as np
 
 from .tree_utils import _build_tree, _xyz_from_ra_dec
+
+
+def ra_dec_nearest_interp(nside, in_array, ra, dec):
+    """Interpolate using nearest neighbor for a given RA,dec.
+    Averages results if more than one HEALpix center is equally close.
+
+    Parameters
+    ----------
+    nside : `int`
+        HEALpix nside
+    in_array : `np.NDarray`
+        A valid HEALpix array
+    ra : `float`
+        RA value(s) to interpolate in_array to using nearest neighbor.
+    dec : `float`
+        Dec value(s) to interpolate in_array to using nearest neighbor.
+    """
+
+    # returns the 4 closest
+    hpid, weights = hp.get_interp_weights(nside, ra, dec, lonlat=True)
+
+    # Find the max weight for each RA,dec
+    m_weight = np.max(weights, axis=0) * np.ones(weights.shape)
+
+    final_weights = np.ones(weights.shape)
+    # Anything less than the max, set to zero weight
+    final_weights[np.where(weights < m_weight)] = 0
+    # Normalize in case there was more than one at the max value
+    final_weights = final_weights / np.sum(final_weights, axis=0)
+
+    result = np.sum(in_array[hpid] * final_weights, axis=0)
+    return result
 
 
 def _hpid2_ra_dec(nside, hpids, **kwargs):

--- a/rubin_scheduler/utils/healpy_utils.py
+++ b/rubin_scheduler/utils/healpy_utils.py
@@ -21,24 +21,24 @@ import numpy as np
 from .tree_utils import _build_tree, _xyz_from_ra_dec
 
 
-def ra_dec_nearest_interp(nside, in_array, ra, dec):
+def ra_dec_nearest_interp(ra, dec, in_array):
     """Interpolate using nearest neighbor for a given RA,dec.
     Averages results if more than one HEALpix center is equally close.
 
     Parameters
     ----------
-    nside : `int`
-        HEALpix nside
-    in_array : `np.NDarray`
-        A valid HEALpix array
     ra : `float`
         RA value(s) to interpolate in_array to using nearest neighbor.
+        Degrees.
     dec : `float`
         Dec value(s) to interpolate in_array to using nearest neighbor.
+        Degrees.
+    in_array : `np.NDarray`
+        A valid HEALpix array
     """
 
     # returns the 4 closest
-    hpid, weights = hp.get_interp_weights(nside, ra, dec, lonlat=True)
+    hpid, weights = hp.get_interp_weights(hp.npix2nside(np.size(in_array)), ra, dec, lonlat=True)
 
     # Find the max weight for each RA,dec
     m_weight = np.max(weights, axis=0) * np.ones(weights.shape)


### PR DESCRIPTION
* Update the QueueManager so masked pixels don't grow. 
* add kward to `MaskAfterNObsSeeingBasisFunction` so it can be continuous or reset per season
* Update scheduler_note on blob surveys so it records how many observations are being attempted in a blob (so it's easy to see how much it may have expanded/contracted blob from ideal pair time)