### PR TITLE
SP-3167: Handle special cases of add_observations_array

### DIFF
--- a/rubin_scheduler/scheduler/schedulers/core_scheduler.py
+++ b/rubin_scheduler/scheduler/schedulers/core_scheduler.py
@@ -160,6 +160,10 @@ class CoreScheduler:
         the observation array and constructed observations + healpix id
         to each survey.
         """
+        if len(obs) == 1:
+            self.add_observation(obs)
+            return
+
         # Need to add "band" here if it wasn't populated
         missing_band = np.where(obs["band"] == "")
         band = np.char.rstrip(obs["filter"][missing_band], chars="_0123456789")

--- a/rubin_scheduler/scheduler/surveys/base_survey.py
+++ b/rubin_scheduler/scheduler/surveys/base_survey.py
@@ -205,15 +205,17 @@ class BaseSurvey:
             not_ignore = np.where(np.char.find(observations_hpid["scheduler_note"], ig) == -1)[0]
             observations_hpid = observations_hpid[not_ignore]
 
-        for feature in self.extra_features:
-            self.extra_features[feature].add_observations_array(observations_array, observations_hpid)
-        for bf in self.extra_basis_functions:
-            self.extra_basis_functions[bf].add_observations_array(observations_array, observations_hpid)
-        for bf in self.basis_functions:
-            bf.add_observations_array(observations_array, observations_hpid)
-        for detailer in self.detailers:
-            detailer.add_observations_array(observations_array, observations_hpid)
-        self.reward_checked = False
+        if len(observations_array) > 0:
+            # Only add observations when they were not all ignored.
+            for feature in self.extra_features:
+                self.extra_features[feature].add_observations_array(observations_array, observations_hpid)
+            for bf in self.extra_basis_functions:
+                self.extra_basis_functions[bf].add_observations_array(observations_array, observations_hpid)
+            for bf in self.basis_functions:
+                bf.add_observations_array(observations_array, observations_hpid)
+            for detailer in self.detailers:
+                detailer.add_observations_array(observations_array, observations_hpid)
+            self.reward_checked = False
 
     def add_observation(self, observation, **kwargs):
         # Check each posible ignore string


### PR DESCRIPTION
If the length of the observations_array ends up being zero due to ignoring all incoming observations, some features can crash -- so this PR adds a check first. 

In addition, if add_observations_array is handed a length 1 array, things can fail in finding the healpix ids, so fall back to just add_observation. 

These are edge-cases, but I found them when doing the following: 
* set up a CoreScheduler with all observations prior to the current night
* add on-going observations so far using add_observations_array
* if the first observations of the night are only twilight_near_earth visits, many other surveys ignore them .. and then features which look for the '.max()' of one of the values will crash because the array is 0 length by that time. 
