### PR TITLE
Tickets/sp 3218

### DIFF
--- a/rubin_scheduler/scheduler/features/conditions.py
+++ b/rubin_scheduler/scheduler/features/conditions.py
@@ -906,8 +906,8 @@ class Conditions:
         moon_phase_sunset : `float`
             The phase of the moon (0-100 illuminated) at sunset.
             Useful for setting which bands should be loaded.
-        targets_of_opportunity : `list` [`rubin_scheduler.scheduler.targetoO`]
-            targetoO objects.
+        targets_of_opportunity : `list` [`TargetoO`]
+            TargetoO objects like `rubin_scheduler.scheduler.utils.TargetoO`.
         planet_positions : `dict` {`str`: `float`}
             Dictionary of planet name and coordinate e.g., 'venus_RA',
             'mars_dec'

--- a/rubin_scheduler/scheduler/schedulers/core_scheduler.py
+++ b/rubin_scheduler/scheduler/schedulers/core_scheduler.py
@@ -254,12 +254,15 @@ class CoreScheduler:
         if self.flush_for_new_too:
             if conditions_in.targets_of_opportunity is not None:
                 if len(conditions_in.targets_of_opportunity) > 0:
-                    current_ids = set([too.id for too in conditions_in.targets_of_opportunity])
-                    new_ids = current_ids.difference(self.too_alert_ids_set)
-                    if len(new_ids) > 0:
-                        self.flush_queue()
-                        for new_id in new_ids:
-                            self.too_alert_ids_set.add(new_id)
+                    current_ids = np.array([too.id for too in conditions_in.targets_of_opportunity])
+                    new_ids = set(current_ids).difference(self.too_alert_ids_set)
+                    for new_id in new_ids:
+                        self.too_alert_ids_set.add(new_id)
+                        # See if this ToO says we should flush the queue
+                        indx = np.where(current_ids == new_id)[0]
+                        for ind in indx:
+                            if conditions_in.targets_of_opportunity[ind].queue_should_flush(conditions_in):
+                                self.flush_queue()
 
         # Add the current queue and scheduled queue to the conditions
         self.conditions = conditions_in

--- a/rubin_scheduler/scheduler/schedulers/core_scheduler.py
+++ b/rubin_scheduler/scheduler/schedulers/core_scheduler.py
@@ -57,6 +57,8 @@ class CoreScheduler:
     queue_manager : `BaseQueueManager`
         A queue manager object. Default None will use the default
         base class.
+    flush_for_new_too : `bool`
+        Flush the queue if a new ToO alert comes in. Default True.
     """
 
     def __init__(
@@ -71,6 +73,7 @@ class CoreScheduler:
         band_to_filter=None,
         survey_start_mjd=SURVEY_START_MJD,
         queue_manager=None,
+        flush_for_new_too=True,
     ):
         if queue_manager is None:
             self.queue_manager = BaseQueueManager()
@@ -118,6 +121,9 @@ class CoreScheduler:
         # Set to something so it doesn't fail if never set later
         self.queue_fill_mjd_ns = -1
         self.queue_reward_df = None
+
+        self.flush_for_new_too = flush_for_new_too
+        self.too_alert_ids_set = set()
 
         # Set mapping of band to filter if filter is missing
         if band_to_filter is None:
@@ -244,6 +250,17 @@ class CoreScheduler:
             The current conditions of the telescope (pointing position,
             loaded filters, cloud-mask, etc)
         """
+
+        if self.flush_for_new_too:
+            if conditions_in.targets_of_opportunity is not None:
+                if len(conditions_in.targets_of_opportunity) > 0:
+                    current_ids = set([too.id for too in conditions_in.targets_of_opportunity])
+                    new_ids = current_ids.difference(self.too_alert_ids_set)
+                    if len(new_ids) > 0:
+                        self.flush_queue()
+                        for new_id in new_ids:
+                            self.too_alert_ids_set.add(new_id)
+
         # Add the current queue and scheduled queue to the conditions
         self.conditions = conditions_in
 

--- a/rubin_scheduler/scheduler/sim_runner.py
+++ b/rubin_scheduler/scheduler/sim_runner.py
@@ -38,6 +38,7 @@ def sim_runner(
     telescope="rubin",
     snapshot_dir="",
     save_on_fail=True,
+    update_conditions_every_obs=False,
 ):
     """
     run a simulation
@@ -78,6 +79,10 @@ def sim_runner(
         observations, and desired observation in the event of a crash.
         Helpful for debugging surveys that are requesting out of
         bounds pointings.
+    update_conditions_every_obs : `bool`
+        Update the conditions after every observation. Useful for
+        checking if ToOs are causing proper queue flushes.
+        Default False.
     """
 
     if extra_info is None:
@@ -149,10 +154,16 @@ def sim_runner(
             with gzip.open(snapshot_fname, "wb", compresslevel=1) as pio:
                 pickle.dump([scheduler, observatory.return_conditions()], file=pio)
 
+        conditions_not_updated = True
         if not hasattr(scheduler, "conditions"):
             scheduler.update_conditions(observatory.return_conditions())
+            conditions_not_updated = False
 
         if not scheduler._check_queue_mjd_only(observatory.mjd):
+            scheduler.update_conditions(observatory.return_conditions())
+            conditions_not_updated = False
+
+        if update_conditions_every_obs & conditions_not_updated:
             scheduler.update_conditions(observatory.return_conditions())
 
         desired_obs = scheduler.request_observation(mjd=observatory.mjd)

--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -40,6 +40,7 @@ from rubin_scheduler import __version__
 from rubin_scheduler.scheduler.utils.observation_array import ObservationArray
 from rubin_scheduler.utils import (
     DEFAULT_NSIDE,
+    _approx_ra_dec2_alt_az,
     _build_tree,
     _hpid2_ra_dec,
     _xyz_from_ra_dec,
@@ -966,6 +967,13 @@ class TargetoO:
         The type of ToO that is made.
     posterior_distance : `float`
         The posterior distance of the event. (kpc)
+    interrupt_queue : `bool`
+        This ToO is urgent, so if it is high enoug in the
+        sky, the scheduler should flush its queue so ToO
+        observations can start without waiting.
+    alt_limit : `float`
+        Altitude limit that some part of the ToO footprint
+        must be above to trigger a queue flush (degrees).
     """
 
     def __init__(
@@ -978,6 +986,8 @@ class TargetoO:
         dec_rad_center=None,
         too_type=None,
         posterior_distance=None,
+        interrupt_queue=True,
+        alt_limit=-20,
     ):
         self.footprint = footprint
         self.duration = duration
@@ -987,6 +997,40 @@ class TargetoO:
         self.dec_rad_center = dec_rad_center
         self.too_type = too_type
         self.posterior_distance = posterior_distance
+
+        self.alt_limit = np.radians(alt_limit)
+        self.interrupt_queue = interrupt_queue
+
+    def queue_should_flush(self, conditions):
+        """Given current conditions, is the ToO
+        probably visible and should interrupt the queue
+        """
+
+        # Kwarg set saying don't interrupt
+        if not self.interrupt_queue:
+            return False
+
+        result = True
+
+        # If we have a ra,dec center, check it is above alt limit
+        if self.ra_rad_center is not None:
+            alt, az = _approx_ra_dec2_alt_az(
+                self.ra_rad_center,
+                self.dec_rad_center,
+                conditions.site.latitude_rad,
+                conditions.site.longitude_rad,
+                conditions.mjd,
+            )
+            if alt < self.alt_limit:
+                result = False
+        # No ra,dec center, check if any part of footprint
+        # is above alt limit.
+        else:
+            indx = np.where(conditions.alt >= self.alt_limit)[0]
+            if np.max(self.footprint[indx]) == 0:
+                result = False
+
+        return result
 
 
 class SimTargetooServer:

--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -987,7 +987,7 @@ class TargetoO:
         too_type=None,
         posterior_distance=None,
         interrupt_queue=True,
-        alt_limit=-20,
+        alt_limit=20,
     ):
         self.footprint = footprint
         self.duration = duration

--- a/tests/scheduler/test_coresched.py
+++ b/tests/scheduler/test_coresched.py
@@ -164,6 +164,27 @@ class TestCoreSched(unittest.TestCase):
         # Sending that in should have cleared the queue
         assert len(sched.queue_manager.desired_observations_array) == 0
 
+        # Set the ToO to not interrupt
+        new_too_event = TargetoO(
+            12, np.ones(hp.nside2npix(conditions.nside)), conditions.mjd, 2, interrupt_queue=False
+        )
+        conditions.targets_of_opportunity = [new_too_event]
+        sched._fill_queue()
+        # Check there is something in the queue
+        assert len(sched.queue_manager.desired_observations_array) > 0
+        # Add ToOs that should not interrupt
+        sched.update_conditions(conditions)
+        assert len(sched.queue_manager.desired_observations_array) > 0
+
+        # Event that wants to interrupt, but has all zero footprint, so
+        # should not flush
+        new_too_event = TargetoO(
+            13, np.zeros(hp.nside2npix(conditions.nside)), conditions.mjd, 2, interrupt_queue=True
+        )
+        conditions.targets_of_opportunity = [new_too_event]
+        sched.update_conditions(conditions)
+        assert len(sched.queue_manager.desired_observations_array) > 0
+
         # Again, but set to not flush on new ToO
         conditions = observatory.return_conditions()
         survey = DummySurvey()

--- a/tests/scheduler/test_coresched.py
+++ b/tests/scheduler/test_coresched.py
@@ -1,6 +1,7 @@
 import unittest
 import warnings
 
+import healpy as hp
 import numpy as np
 import pandas as pd
 
@@ -10,7 +11,17 @@ import rubin_scheduler.scheduler.surveys as surveys
 from rubin_scheduler.scheduler.example import simple_greedy_survey
 from rubin_scheduler.scheduler.model_observatory import ModelObservatory
 from rubin_scheduler.scheduler.schedulers import BaseQueueManager, CoreScheduler
-from rubin_scheduler.scheduler.utils import ObservationArray
+from rubin_scheduler.scheduler.utils import ObservationArray, TargetoO
+
+
+class DummySurvey(surveys.BaseSurvey):
+    def __init__(self):
+        super().__init__([], [])
+
+    def generate_observations(self, *args, **kwargs):
+        result = ObservationArray(n=10)
+        result["band"] = "r"
+        return result
 
 
 class TestCoreSched(unittest.TestCase):
@@ -114,6 +125,61 @@ class TestCoreSched(unittest.TestCase):
 
         assert recorded["mjd"] == 100
         assert recorded["scheduler_note"] == "survey"
+
+    def test_too_flush(self):
+        """Test that the queue will flush if a new ToO comes in"""
+        observatory = ModelObservatory()
+
+        conditions = observatory.return_conditions()
+        survey = DummySurvey()
+        sched = CoreScheduler([survey], flush_for_new_too=True)
+        sched.update_conditions(conditions)
+        sched._fill_queue()
+
+        # Make sure we have things in the queue
+        assert len(sched.queue_manager.desired_observations_array) > 0
+
+        new_too_event = TargetoO(1, np.ones(hp.nside2npix(conditions.nside)), conditions.mjd, 2)
+        conditions.targets_of_opportunity = [new_too_event]
+
+        sched.update_conditions(conditions)
+        # New ToO should result in queue being cleared
+        assert len(sched.queue_manager.desired_observations_array) == 0
+
+        # Check that sending in a same ID ToO doesn't result in a new flush
+        sched._fill_queue()
+        # Check there is something in the queue
+        assert len(sched.queue_manager.desired_observations_array) > 0
+        # Update conditions. There is a ToO in the list, but
+        # scheduler should recognize it's already seen it and not flush.
+        sched.update_conditions(conditions)
+        assert len(sched.queue_manager.desired_observations_array) > 0
+
+        # Now make a ToO with a new ID
+        new_too_event = TargetoO(10, np.ones(hp.nside2npix(conditions.nside)), conditions.mjd, 2)
+        conditions.targets_of_opportunity = [new_too_event]
+        # Make sure we have something in the queue
+        assert len(sched.queue_manager.desired_observations_array) > 0
+        sched.update_conditions(conditions)
+        # Sending that in should have cleared the queue
+        assert len(sched.queue_manager.desired_observations_array) == 0
+
+        # Again, but set to not flush on new ToO
+        conditions = observatory.return_conditions()
+        survey = DummySurvey()
+        sched = CoreScheduler([survey], flush_for_new_too=False)
+        sched.update_conditions(conditions)
+        sched._fill_queue()
+
+        # Make sure we have something in the queue
+        assert len(sched.queue_manager.desired_observations_array) > 0
+
+        new_too_event = TargetoO(1, np.ones(hp.nside2npix(conditions.nside)), conditions.mjd, 2)
+        conditions.targets_of_opportunity = [new_too_event]
+
+        sched.update_conditions(conditions)
+        # We sent in a new ToO, but should not have flushed.
+        assert len(sched.queue_manager.desired_observations_array) > 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
New kwarg so `CoreScheduler` will flush its queue if a new ToO event is passed in via `update_conditions`. No checking if the ToO is actually visible, so it's up to the user to confirm they think the ToO is worth flushing the queue for before sending it in. Or, if the user is fine interrupting something like pairs to be sure the ToO doesn't have observations that can be done immediately. 