### PR TITLE
SP-3269: make duration a kwarg with a default

### DIFF
--- a/rubin_scheduler/scheduler/utils/__init__.py
+++ b/rubin_scheduler/scheduler/utils/__init__.py
@@ -2,5 +2,6 @@ from .comcam_tessellate import *
 from .footprints import *
 from .observation_array import *
 from .sky_area import *
+from .too_objects import *
 from .tsp import *
 from .utils import *

--- a/rubin_scheduler/scheduler/utils/too_objects.py
+++ b/rubin_scheduler/scheduler/utils/too_objects.py
@@ -1,0 +1,120 @@
+import numpy as np
+
+from rubin_scheduler.utils import _approx_ra_dec2_alt_az
+
+__all__ = [
+    "TargetoO",
+    "SimTargetooServer",
+]
+
+
+class TargetoO:
+    """Class to hold information about a target of opportunity object
+
+    Parameters
+    ----------
+    tooid : `str`
+        Unique ID for the ToO. Probably using `source` from EFD.
+    footprints : `np.array`
+        np.array healpix maps. 1 for areas to observe, 0 for no observe.
+        Can use np.nan for no-observe pixels, but that will be interpreted
+        to mean the map cannot expand if the resolution chages.
+    mjd_start : `float`
+        The MJD the ToO starts
+    duration : `float`
+        Duration of the ToO (days).
+    ra_rad_center : `float`
+        RA of the estimated center of the event (radians).
+    dec_rad_center : `float`
+        Dec of the estimated center of the event (radians).
+    too_type : `str`
+        The type of ToO that is made.
+    posterior_distance : `float`
+        The posterior distance of the event. (kpc)
+    interrupt_queue : `bool`
+        This ToO is urgent, so if it is high enoug in the
+        sky, the scheduler should flush its queue so ToO
+        observations can start without waiting.
+    alt_limit : `float`
+        Altitude limit that some part of the ToO footprint
+        must be above to trigger a queue flush (degrees).
+    """
+
+    def __init__(
+        self,
+        tooid,
+        footprint,
+        mjd_start,
+        duration=None,
+        ra_rad_center=None,
+        dec_rad_center=None,
+        too_type=None,
+        posterior_distance=None,
+        interrupt_queue=True,
+        alt_limit=20,
+    ):
+        self.footprint = footprint
+        self.duration = duration
+        self.id = tooid
+        self.mjd_start = mjd_start
+        self.ra_rad_center = ra_rad_center
+        self.dec_rad_center = dec_rad_center
+        self.too_type = too_type
+        self.posterior_distance = posterior_distance
+
+        self.alt_limit = np.radians(alt_limit)
+        self.interrupt_queue = interrupt_queue
+
+    def queue_should_flush(self, conditions):
+        """Given current conditions, is the ToO
+        probably visible and should interrupt the queue
+        """
+
+        # Kwarg set saying don't interrupt
+        if not self.interrupt_queue:
+            return False
+
+        result = True
+
+        # If we have a ra,dec center, check it is above alt limit
+        if self.ra_rad_center is not None:
+            alt, az = _approx_ra_dec2_alt_az(
+                self.ra_rad_center,
+                self.dec_rad_center,
+                conditions.site.latitude_rad,
+                conditions.site.longitude_rad,
+                conditions.mjd,
+            )
+            if alt < self.alt_limit:
+                result = False
+        # No ra,dec center, check if any part of footprint
+        # is above alt limit.
+        else:
+            indx = np.where(conditions.alt >= self.alt_limit)[0]
+            # footprint pixels could be NaN for not-observe, use 0 here.
+            fp_pix = np.nan_to_num(self.footprint[indx], copy=True, nan=0)
+            if np.max(fp_pix) == 0:
+                result = False
+
+        return result
+
+
+class SimTargetooServer:
+    """Wrapper to deliver a targetoO object at the right time"""
+
+    def __init__(self, targeto_o_list):
+        self.targeto_o_list = targeto_o_list
+        self.mjd_starts = np.array([too.mjd_start for too in self.targeto_o_list])
+        durations = np.array([too.duration for too in self.targeto_o_list], dtype="float")
+        # Fill any Nans with a default value.
+        # This should never be necessary in full simulations, where duration
+        # is always set by gen_events.
+        np.nan_to_num(durations, copy=False, nan=3)
+        self.mjd_ends = self.mjd_starts + durations
+
+    def __call__(self, mjd):
+        in_range = np.where((mjd > self.mjd_starts) & (mjd < self.mjd_ends))[0]
+        result = None
+        if in_range.size > 0:
+            result = [self.targeto_o_list[i] for i in in_range]
+        return result

--- a/rubin_scheduler/scheduler/utils/utils.py
+++ b/rubin_scheduler/scheduler/utils/utils.py
@@ -6,8 +6,6 @@ __all__ = (
     "HpInComcamFov",
     "HpInLsstFov",
     "hp_kd_tree",
-    "TargetoO",
-    "SimTargetooServer",
     "restore_scheduler",
     "warm_start",
     "gnomonic_project_toxy",
@@ -40,7 +38,6 @@ from rubin_scheduler import __version__
 from rubin_scheduler.scheduler.utils.observation_array import ObservationArray
 from rubin_scheduler.utils import (
     DEFAULT_NSIDE,
-    _approx_ra_dec2_alt_az,
     _build_tree,
     _hpid2_ra_dec,
     _xyz_from_ra_dec,
@@ -942,109 +939,3 @@ def create_season_offset(nside, sun_ra_rad):
     offset = offset * 365.25 / (np.pi * 2)
     offset = -offset - 365.25
     return offset
-
-
-class TargetoO:
-    """Class to hold information about a target of opportunity object
-
-    Parameters
-    ----------
-    tooid : `str`
-        Unique ID for the ToO. Probably using `source` from EFD.
-    footprints : `np.array`
-        np.array healpix maps. 1 for areas to observe, 0 for no observe.
-        Can use np.nan for no-observe pixels, but that will be interpreted
-        to mean the map cannot expand if the resolution chages.
-    mjd_start : `float`
-        The MJD the ToO starts
-    duration : `float`
-        Duration of the ToO (days).
-    ra_rad_center : `float`
-        RA of the estimated center of the event (radians).
-    dec_rad_center : `float`
-        Dec of the estimated center of the event (radians).
-    too_type : `str`
-        The type of ToO that is made.
-    posterior_distance : `float`
-        The posterior distance of the event. (kpc)
-    interrupt_queue : `bool`
-        This ToO is urgent, so if it is high enoug in the
-        sky, the scheduler should flush its queue so ToO
-        observations can start without waiting.
-    alt_limit : `float`
-        Altitude limit that some part of the ToO footprint
-        must be above to trigger a queue flush (degrees).
-    """
-
-    def __init__(
-        self,
-        tooid,
-        footprint,
-        mjd_start,
-        duration,
-        ra_rad_center=None,
-        dec_rad_center=None,
-        too_type=None,
-        posterior_distance=None,
-        interrupt_queue=True,
-        alt_limit=20,
-    ):
-        self.footprint = footprint
-        self.duration = duration
-        self.id = tooid
-        self.mjd_start = mjd_start
-        self.ra_rad_center = ra_rad_center
-        self.dec_rad_center = dec_rad_center
-        self.too_type = too_type
-        self.posterior_distance = posterior_distance
-
-        self.alt_limit = np.radians(alt_limit)
-        self.interrupt_queue = interrupt_queue
-
-    def queue_should_flush(self, conditions):
-        """Given current conditions, is the ToO
-        probably visible and should interrupt the queue
-        """
-
-        # Kwarg set saying don't interrupt
-        if not self.interrupt_queue:
-            return False
-
-        result = True
-
-        # If we have a ra,dec center, check it is above alt limit
-        if self.ra_rad_center is not None:
-            alt, az = _approx_ra_dec2_alt_az(
-                self.ra_rad_center,
-                self.dec_rad_center,
-                conditions.site.latitude_rad,
-                conditions.site.longitude_rad,
-                conditions.mjd,
-            )
-            if alt < self.alt_limit:
-                result = False
-        # No ra,dec center, check if any part of footprint
-        # is above alt limit.
-        else:
-            indx = np.where(conditions.alt >= self.alt_limit)[0]
-            if np.max(self.footprint[indx]) == 0:
-                result = False
-
-        return result
-
-
-class SimTargetooServer:
-    """Wrapper to deliver a targetoO object at the right time"""
-
-    def __init__(self, targeto_o_list):
-        self.targeto_o_list = targeto_o_list
-        self.mjd_starts = np.array([too.mjd_start for too in self.targeto_o_list])
-        durations = np.array([too.duration for too in self.targeto_o_list])
-        self.mjd_ends = self.mjd_starts + durations
-
-    def __call__(self, mjd):
-        in_range = np.where((mjd > self.mjd_starts) & (mjd < self.mjd_ends))[0]
-        result = None
-        if in_range.size > 0:
-            result = [self.targeto_o_list[i] for i in in_range]
-        return result

--- a/tests/scheduler/test_targetoo.py
+++ b/tests/scheduler/test_targetoo.py
@@ -1,0 +1,198 @@
+import unittest
+
+import numpy as np
+
+from rubin_scheduler.scheduler.features import Conditions
+from rubin_scheduler.scheduler.utils import SimTargetooServer, TargetoO
+from rubin_scheduler.utils import SURVEY_START_MJD, Site, _approx_ra_dec2_alt_az
+
+
+def make_conditions(mjd):
+    conditions = Conditions(mjd=mjd)
+    return conditions
+
+
+class TestTargetoO(unittest.TestCase):
+    def test_init_required_args(self):
+        footprint = np.array([1, 0, 1, 0])
+        too = TargetoO(tooid="too_1", footprint=footprint, mjd_start=SURVEY_START_MJD)
+        np.testing.assert_array_equal(too.footprint, footprint)
+        self.assertEqual(too.id, "too_1")
+        self.assertEqual(too.mjd_start, SURVEY_START_MJD)
+        # Check if default kwargs have remained as expected.
+        # But update if reasonable.
+        self.assertIsNone(too.duration)
+        self.assertIsNone(too.ra_rad_center)
+        self.assertIsNone(too.dec_rad_center)
+        self.assertIsNone(too.too_type)
+        self.assertIsNone(too.posterior_distance)
+        self.assertTrue(too.interrupt_queue)
+
+    def test_init_all_args(self):
+        footprint = np.array([1, 1, 0, 0])
+        too = TargetoO(
+            tooid="too_2",
+            footprint=footprint,
+            mjd_start=SURVEY_START_MJD + 2,
+            duration=3.0,
+            ra_rad_center=1.0,
+            dec_rad_center=-0.5,
+            too_type="GW",
+            posterior_distance=40.0,
+            interrupt_queue=False,
+            alt_limit=30,
+        )
+        self.assertEqual(too.id, "too_2")
+        self.assertEqual(too.duration, 3.0)
+        self.assertEqual(too.ra_rad_center, 1.0)
+        self.assertEqual(too.dec_rad_center, -0.5)
+        self.assertEqual(too.too_type, "GW")
+        self.assertEqual(too.posterior_distance, 40.0)
+        self.assertFalse(too.interrupt_queue)
+        self.assertAlmostEqual(too.alt_limit, np.radians(30))
+
+    def test_interrupt_queue_disabled_returns_false(self):
+        # Check if queue interrupt is false when kwarg is set False.
+        too = TargetoO(
+            tooid="too_a",
+            footprint=np.array([1, 0]),
+            mjd_start=SURVEY_START_MJD,
+            interrupt_queue=False,
+        )
+        self.assertFalse(too.queue_should_flush(make_conditions(mjd=SURVEY_START_MJD)))
+
+    def test_radec_center_above_alt_limit_returns_true(self):
+        # Might need to adjust this position with new SURVEY_START_MJD?
+        ra_center = 2.0
+        dec_center = -0.4
+        mjd = SURVEY_START_MJD
+        lsst = Site("LSST")
+        expected_alt, expected_az = _approx_ra_dec2_alt_az(
+            ra_center, dec_center, lsst.latitude_rad, lsst.longitude_rad, mjd=mjd
+        )
+        too = TargetoO(
+            tooid="too_b",
+            footprint=np.array([1, 0]),
+            mjd_start=mjd,
+            ra_rad_center=ra_center,
+            dec_rad_center=dec_center,
+            alt_limit=np.degrees(expected_alt) - 10,
+        )
+        self.assertTrue(too.queue_should_flush(make_conditions(mjd=mjd)))
+
+    def test_radec_center_below_alt_limit_returns_false(self):
+        ra_center = 2.0
+        dec_center = -0.4
+        mjd = SURVEY_START_MJD
+        lsst = Site("LSST")
+        expected_alt, expected_az = _approx_ra_dec2_alt_az(
+            ra_center, dec_center, lsst.latitude_rad, lsst.longitude_rad, mjd=mjd
+        )
+        too = TargetoO(
+            tooid="too_c",
+            footprint=np.array([1, 0]),
+            mjd_start=mjd,
+            ra_rad_center=ra_center,
+            dec_rad_center=dec_center,
+            alt_limit=np.degrees(expected_alt) + 10,
+        )
+        self.assertFalse(too.queue_should_flush(make_conditions(mjd=mjd)))
+
+    def test_footprint_visible_above_alt_limit_returns_true(self):
+        # Make the conditions
+        conditions = make_conditions(SURVEY_START_MJD)
+        # Then pull out a couple of ra/dec positions for the "footprint"
+        # using those altitude limits.
+        idx = np.where(conditions.alt > np.radians(30))
+        footprint = np.zeros(len(conditions.alt))
+        footprint[idx[0:3]] = 1
+        too = TargetoO(tooid="too_d", footprint=footprint, mjd_start=SURVEY_START_MJD, alt_limit=30)
+        self.assertTrue(too.queue_should_flush(conditions))
+
+    def test_footprint_only_zero_pixels_above_limit_returns_false(self):
+        # Make the conditions
+        conditions = make_conditions(SURVEY_START_MJD)
+        # Then pull out a couple of ra/dec positions for the "footprint"
+        # using those altitude limits.
+        idx = np.where(conditions.alt > np.radians(30))
+        footprint = np.ones(len(conditions.alt))
+        footprint[idx] = 0
+        too = TargetoO(tooid="too_e", footprint=footprint, mjd_start=SURVEY_START_MJD, alt_limit=35)
+        self.assertFalse(too.queue_should_flush(conditions))
+
+
+def make_too(tooid, mjd_start, duration):
+    """Build a real TargetoO with a minimal footprint."""
+    return TargetoO(
+        tooid=tooid,
+        footprint=np.array([1, 0]),
+        mjd_start=mjd_start,
+        duration=duration,
+    )
+
+
+class TestSimTargetooServer(unittest.TestCase):
+    def test_init_computes_starts_and_ends(self):
+        toos = [
+            make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0),
+            make_too("b", mjd_start=SURVEY_START_MJD + 10.0, duration=5.0),
+        ]
+        server = SimTargetooServer(toos)
+        np.testing.assert_array_equal(server.mjd_starts, [SURVEY_START_MJD, SURVEY_START_MJD + 10.0])
+        np.testing.assert_array_equal(server.mjd_ends, [SURVEY_START_MJD + 2.0, SURVEY_START_MJD + 15.0])
+
+    def test_call_returns_none_before_any_event(self):
+        toos = [make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0)]
+        server = SimTargetooServer(toos)
+        self.assertIsNone(server(SURVEY_START_MJD - 1.0))
+
+    def test_call_returns_none_after_all_events(self):
+        toos = [make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0)]
+        server = SimTargetooServer(toos)
+        self.assertIsNone(server(SURVEY_START_MJD + 3.0))
+
+    def test_call_returns_active_event(self):
+        toos = [make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0)]
+        server = SimTargetooServer(toos)
+        result = server(SURVEY_START_MJD + 1.0)
+        self.assertIsNotNone(result)
+        self.assertEqual([too.id for too in result], ["a"])
+
+    def test_call_returns_multiple_overlapping_events(self):
+        toos = [
+            make_too("a", mjd_start=SURVEY_START_MJD, duration=5.0),  # +0 .. +5
+            make_too("b", mjd_start=SURVEY_START_MJD + 2.0, duration=5.0),  # +2 .. +7
+        ]
+        server = SimTargetooServer(toos)
+        result = server(SURVEY_START_MJD + 3.0)  # both active
+        self.assertEqual([too.id for too in result], ["a", "b"])
+
+    def test_call_returns_only_currently_active_event(self):
+        toos = [
+            make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0),  # +0 .. +2
+            make_too("b", mjd_start=SURVEY_START_MJD + 10.0, duration=2.0),  # +10 .. +12
+        ]
+        server = SimTargetooServer(toos)
+        result = server(SURVEY_START_MJD + 11.0)
+        self.assertEqual([too.id for too in result], ["b"])
+
+    def test_call_boundary_is_exclusive_at_start(self):
+        # Condition is (mjd > start) & (mjd < end) -> strict inequalities.
+        toos = [make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0)]
+        server = SimTargetooServer(toos)
+        self.assertIsNone(server(SURVEY_START_MJD))  # exactly at start -> excluded
+
+    def test_call_boundary_is_exclusive_at_end(self):
+        toos = [make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0)]
+        server = SimTargetooServer(toos)
+        self.assertIsNone(server(SURVEY_START_MJD + 2.0))  # exactly at end -> excluded
+
+    def test_call_returns_objects_not_indices(self):
+        toos = [make_too("a", mjd_start=SURVEY_START_MJD, duration=2.0)]
+        server = SimTargetooServer(toos)
+        result = server(SURVEY_START_MJD + 1.0)
+        self.assertIs(result[0], toos[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Made TargetooO  'duration' default to None instead of being a mandatory argument. SchedulerCSC does not want to fill this number for ToO (and the duration is not relevant to FBS execution itself, only the SimTooServer, which gets filled by the summit in operations .. we need to match summit, but will probably need other machinery).  Tiago requested that it be changed so he does not have to send a value here.
Using "None" is somewhat arbitrary, but is distinguishable from real float values set on purpose. Note that SimToOServer fills in 3 at present, for cases of None so even if not set, will work as it does at present in simulations.
The duration is useful for simulations so is still available to use (even if sim ToOs all seem to use 3 at present).

Moved TargetofO and simTargetooServer to their own files, to make them easier to find. 

I added unit tests for both TargetoO and simTargetooServer. 
In doing so, the fact that nan pixels in the footprint could be the "np.max" value and still not evaluate == 0 came up .. which would have left "queue flush" = True instead of flipping it to False. I added some extra code to handle this case. (the doctstring says np.nan can be used for do-not-observe pixels). 